### PR TITLE
Easy older go compat

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -38,7 +38,7 @@ func (b Bot) Listen(subscription chan<- Message, interval time.Duration) {
 	latestUpdate := 0
 
 	go func() {
-		for range pulse.C {
+		for _ = range pulse.C {
 			go getUpdates(b.Token,
 				latestUpdate+1,
 				updates)


### PR DESCRIPTION
`go range` without loop values is new to 1.4. some of us are stuck with older go (wheezy backport is 1.3.3). Merge if you wish - this was a quick one.

Fixes #2