### PR TITLE
Support custom keyboard

### DIFF
--- a/api.go
+++ b/api.go
@@ -95,9 +95,10 @@ func embedSendOptions(params *url.Values, options *SendOptions) {
 		params.Set("disable_web_page_preview", "true")
 	}
 
-	if options.ForceReply.Require {
-		forceReply, _ := json.Marshal(options.ForceReply)
-		params.Set("reply_markup", string(forceReply))
+	// process reply_markup
+	if options.ReplyMarkup.ForceReply || options.ReplyMarkup.CustomKeyboard != nil || options.ReplyMarkup.HideCustomKeyboard {
+		replyMarkup, _ := json.Marshal(options.ReplyMarkup)
+		params.Set("reply_markup", string(replyMarkup))
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -6,19 +6,38 @@ type SendOptions struct {
 	// If the message is a reply, original message.
 	ReplyTo Message
 
-	// See ForceReply struct definition.
-	ForceReply ForceReply
+	// See ReplyMarkup struct definition.
+	ReplyMarkup ReplyMarkup
 
 	// For text messages, disables previews for links in this message.
 	DisableWebPagePreview bool
 }
 
-// ForceReply forces Telegram clients to display
-// a reply interface to the user (act as if the user
-// has selected the bot‘s message and tapped "Reply").
-type ForceReply struct {
-	// Enable if intended.
-	Require bool `json:"force_reply"`
+type ReplyMarkup struct {
+	// ForceReply forces Telegram clients to display
+	// a reply interface to the user (act as if the user
+	// has selected the bot‘s message and tapped "Reply").
+	ForceReply bool `json:"force_reply,omitempty"`
+
+
+	// CustomKeyboard is Array of button rows, each represented by an Array of Strings.
+	//
+	// Note: you don't need to set HideCustomKeyboard field to show custom keyboard.
+	CustomKeyboard [][]string `json:"keyboard,omitempty"`
+	// Requests clients to resize the keyboard vertically for optimal fit
+	// (e.g., make the keyboard smaller if there are just two rows of buttons).
+	// Defaults to false, in which case the custom keyboard is always of the
+	// same height as the app's standard keyboard.
+	ResizeKeyboard bool `json:"resize_keyboar,omitemptyd"`
+	// Requests clients to hide the keyboard as soon as it's been used. Defaults to false.
+	OneTimeKeyboard bool `json:"one_time_keyboard,omitempty"`
+
+
+	// Requests clients to hide the custom keyboard.
+	//
+	// Note: You dont need to set CustomKeyboard field to hide custom keyboard.
+	HideCustomKeyboard bool `json:"hide_keyboard,omitempty"`
+
 
 	// Use this param if you want to force reply from
 	// specific users only.
@@ -27,5 +46,5 @@ type ForceReply struct {
 	// 1) Users that are @mentioned in the text of the Message object;
 	// 2) If the bot's message is a reply (has SendOptions.ReplyTo),
 	//       sender of the original message.
-	Selective bool `json:"selective"`
+	Selective bool `json:"selective,omitempty"`
 }


### PR DESCRIPTION
As in [Official API document](https://core.telegram.org/bots/api/#sendmessage), custom keyboard and force reply are packed in same parameter. So I renamed `ForceReply` to `ReplyMarkup` to fit this.

This should fix #1