### PR TITLE
Change API to return error on 500 http status.

### DIFF
--- a/api.go
+++ b/api.go
@@ -74,6 +74,10 @@ func sendFile(method, token, name, path string, params url.Values) ([]byte, erro
 		return []byte{}, err
 	}
 
+	if resp.StatusCode == http.StatusInternalServerError {
+		return []byte{}, fmt.Errorf("Telegram API returned 500 internal server error")
+	}
+
 	json, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return []byte{}, err


### PR DESCRIPTION
- The Telegram Bot API does not return well-formed JSON when there is an internal server error. It instead returns HTML. This results in incomprehensible errors from attempting to unmarshal the HTML as JSON.
- This pull request changes behaviour to look at the http status from the HTTP Client's response before creating and returning an error. 

Note: The Telegram bot API seems to return proper JSON for every other status code, though.