### PR TITLE
Add inline response options and offset handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ func queries() {
 		results := []telebot.Result{...}
 
 		// And finally respond to the query:
-		if err := bot.Respond(query, results); err != nil {
+		if err := bot.Respond(query, results, nil); err != nil {
 			log.Println("ouch:", err)
 		}
 	}

--- a/bot.go
+++ b/bot.go
@@ -476,9 +476,27 @@ func (b *Bot) SendChatAction(recipient Recipient, action string) error {
 }
 
 // Respond publishes a set of responses for an inline query.
-func (b *Bot) Respond(query Query, results []Result) error {
+func (b *Bot) Respond(query Query, results []Result, options *AnswerOptions) error {
 	params := url.Values{}
 	params.Set("inline_query_id", query.ID)
+
+	if options != nil {
+		if options.CacheTime != 0 {
+			if options.CacheTime == -1 {
+				params.Set("cache_time", "0")
+			} else {
+				params.Set("cache_time", strconv.Itoa(options.CacheTime))
+			}
+		}
+
+		if options.IsPersonal {
+			params.Set("is_personal", "true")
+		}
+
+		if options.Offset != "" {
+			params.Set("offset", options.Offset)
+		}
+	}
 
 	if res, err := json.Marshal(results); err == nil {
 		params.Set("results", string(res))

--- a/inline.go
+++ b/inline.go
@@ -4,9 +4,10 @@ package telebot
 // an empty query, your bot could return some default or
 // trending results.
 type Query struct {
-	ID   string `json:"id"`
-	From User   `json:"from"`
-	Text string `json:"query"`
+	ID     string `json:"id"`
+	From   User   `json:"from"`
+	Text   string `json:"query"`
+	Offset string `json:"offset"`
 }
 
 // Result ...

--- a/options.go
+++ b/options.go
@@ -29,6 +29,19 @@ type SendOptions struct {
 	ParseMode ParseMode
 }
 
+// AnswerOptions specifies options about responses to inline results
+type AnswerOptions struct {
+	// Cache time (default: 300). Set to -1 to set to 0 (no cache)
+	CacheTime int
+
+	// Cache personality (cache result for this user or for all)
+	// Default: false
+	IsPersonal bool
+
+	// Offset to send back if the client wants more results.
+	Offset string
+}
+
 // ReplyMarkup specifies convenient options for bot-user communications.
 type ReplyMarkup struct {
 	// ForceReply forces Telegram clients to display


### PR DESCRIPTION
I've added support for sending [Inline Query response options](https://core.telegram.org/bots/api#answerinlinequery), such as cache time, cache personality, and offset (which is now parsed from the response).

Note this changes the API to make it similar to the message sending functions, I haven't figured out a way to do it cleanly without that...