### PR TITLE
Adding support for inline keyboard buttons

### DIFF
--- a/api.go
+++ b/api.go
@@ -111,8 +111,9 @@ func embedSendOptions(params *url.Values, options *SendOptions) {
 	{
 		forceReply := options.ReplyMarkup.ForceReply
 		customKeyboard := (options.ReplyMarkup.CustomKeyboard != nil)
+		inlineKeyboard := options.ReplyMarkup.InlineKeyboard != nil
 		hiddenKeyboard := options.ReplyMarkup.HideCustomKeyboard
-		if forceReply || customKeyboard || hiddenKeyboard {
+		if forceReply || customKeyboard || hiddenKeyboard || inlineKeyboard {
 			replyMarkup, _ := json.Marshal(options.ReplyMarkup)
 			params.Set("reply_markup", string(replyMarkup))
 		}

--- a/options.go
+++ b/options.go
@@ -40,6 +40,9 @@ type ReplyMarkup struct {
 	//
 	// Note: you don't need to set HideCustomKeyboard field to show custom keyboard.
 	CustomKeyboard [][]string `json:"keyboard,omitempty"`
+
+	InlineKeyboard [][]KeyboardButton `json:"inline_keyboard,omitempty"`
+
 	// Requests clients to resize the keyboard vertically for optimal fit
 	// (e.g., make the keyboard smaller if there are just two rows of buttons).
 	// Defaults to false, in which case the custom keyboard is always of the

--- a/types.go
+++ b/types.go
@@ -54,11 +54,12 @@ func (c Chat) IsGroupChat() bool {
 
 // Update object represents an incoming update.
 type Update struct {
-	ID      int     `json:"update_id"`
-	Payload Message `json:"message"`
+	ID      int      `json:"update_id"`
+	Payload *Message `json:"message"`
 
 	// optional
-	Query *Query `json:"inline_query"`
+	Callback *Callback `json:"callback_query"`
+	Query    *Query    `json:"inline_query"`
 }
 
 // Thumbnail object represents an image/sticker of a particular size.
@@ -129,6 +130,14 @@ type Video struct {
 	Preview Thumbnail `json:"thumb"`
 }
 
+// KeyboardButton represents a button displayed on in a message.
+type KeyboardButton struct {
+	Text        string `json:"text"`
+	URL         string `json:"url,omitempty"`
+	Data        string `json:"callback_data,omitempty"`
+	InlineQuery string `json:"switch_inline_query,omitempty"`
+}
+
 // Contact object represents a contact to Telegram user
 type Contact struct {
 	UserID      int    `json:"user_id"`
@@ -141,4 +150,14 @@ type Contact struct {
 type Location struct {
 	Longitude float32 `json:"longitude"`
 	Latitude  float32 `json:"latitude"`
+}
+
+type Callback struct {
+	ID string `json:"id"`
+	// For message sent to channels, Sender may be empty
+	Sender User `json:"from"`
+
+	Message Message `json:"message"`
+
+	Data string `json:"data"`
 }

--- a/types.go
+++ b/types.go
@@ -152,12 +152,20 @@ type Location struct {
 	Latitude  float32 `json:"latitude"`
 }
 
+// Callback object represents a query from a callback button in an
+// inline keyboard.
 type Callback struct {
 	ID string `json:"id"`
+
 	// For message sent to channels, Sender may be empty
 	Sender User `json:"from"`
 
+	// Message will be set if the button that originated the query
+	// was attached to a message sent by a bot.
 	Message Message `json:"message"`
 
-	Data string `json:"data"`
+	// MessageID will be set if the button was attached to a message
+	// sent via the bot in inline mode.
+	MessageID string `json:"inline_message_id"`
+	Data      string `json:"data"`
 }


### PR DESCRIPTION
This is my attempt to resolve #38 . Aside from just adding the inline keyboard I also added the functionality to receive the `callback_query` that is returned to the bot whenever a user clicks on a button:

```json
{
    "ok": true,
    "result": [
        {
            "update_id": 719407019,
            "callback_query": {
                "id": "681084473189109588",
                "from": {
                    "id": 158577336,
                    "first_name": "Zaba",
                    "last_name": "waba",
                    "username": "zabawaba"
                },
                "message": {
                    "message_id": 281,
                    "from": {
                        "id": 191481738,
                        "first_name": "Botty",
                        "username": "Botty"
                    },
                    "chat": {
                        "id": 158577336,
                        "first_name": "Zaba",
                        "last_name": "waba",
                        "username": "zabawaba",
                        "type": "private"
                    },
                    "date": 1461726033,
                    "text": "Pick One"
                },
                "data": "foobar"
            }
        }
    ]
}
```