### PR TITLE
support for forwarded messages from channels

### DIFF
--- a/message.go
+++ b/message.go
@@ -16,6 +16,9 @@ type Message struct {
 	// For forwarded messages, sender of the original message.
 	OriginalSender User `json:"forward_from"`
 
+	// For forwarded messages, chat of the original message when forwarded from a channel.
+	OriginalChat Chat `json:"forward_from_chat"`
+
 	// For forwarded messages, unixtime of the original message.
 	OriginalUnixtime int `json:"forward_date"`
 
@@ -151,7 +154,7 @@ func (m *Message) Time() time.Time {
 // IsForwarded says whether message is forwarded copy of another
 // message or not.
 func (m *Message) IsForwarded() bool {
-	return m.OriginalSender != User{}
+	return m.OriginalSender != User{} || m.OriginalChat != Chat{}
 }
 
 // IsReply says whether message is reply to another message or not.


### PR DESCRIPTION
This would fix the problem that forwarded messages from channels don't get detected as forwarded and allows you to get the chat id of the channel the message was originally posted to.