### PR TITLE
Simple pluggable serve-and-handle API

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/armon/go-radix"
 	"github.com/pkg/errors"
 )
 
@@ -20,12 +21,17 @@ type Bot struct {
 	// Telebot debugging channel. If present, Telebot
 	// will use it to report all occuring errors.
 	Errors chan error
+
+	tree *radix.Tree
 }
 
 // NewBot does try to build a Bot with token `token`, which
 // is a secret API key assigned to particular bot.
 func NewBot(token string) (*Bot, error) {
-	bot := &Bot{Token: token}
+	bot := &Bot{
+		Token: token,
+		tree:  radix.New(),
+	}
 
 	user, err := bot.getMe()
 	if err != nil {

--- a/handlers.go
+++ b/handlers.go
@@ -21,7 +21,5 @@ func (b *Bot) Serve(msg *Message) {
 
 	if endpoint, ok := value.(Handler); ok {
 		endpoint(Context{b, msg})
-	} else {
-		panic("telebot: couldn't find a route")
 	}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,27 @@
+package telebot
+
+// Default handler prefix.
+const Default string = ""
+
+type Context struct {
+	Bot *Bot
+	Msg *Message
+}
+
+type Handler func(Context)
+
+func (b *Bot) Handle(prefix string, handler Handler) {
+	b.tree.Insert(prefix, handler)
+}
+
+func (b *Bot) Serve(msg *Message) {
+	request := msg.Text
+
+	_, value, _ := b.tree.LongestPrefix(request)
+
+	if endpoint, ok := value.(Handler); ok {
+		endpoint(Context{b, msg})
+	} else {
+		panic("telebot: couldn't find a route")
+	}
+}

--- a/handlers.go
+++ b/handlers.go
@@ -4,8 +4,8 @@ package telebot
 const Default string = ""
 
 type Context struct {
-	Bot *Bot
-	Msg *Message
+	Bot     *Bot
+	Message *Message
 }
 
 type Handler func(Context)

--- a/handlers.go
+++ b/handlers.go
@@ -5,7 +5,7 @@ const Default string = ""
 
 type Context struct {
 	Bot     *Bot
-	Message *Message
+	Message Message
 }
 
 type Handler func(Context)
@@ -14,7 +14,7 @@ func (b *Bot) Handle(prefix string, handler Handler) {
 	b.tree.Insert(prefix, handler)
 }
 
-func (b *Bot) Serve(msg *Message) {
+func (b *Bot) Serve(msg Message) {
 	request := msg.Text
 
 	_, value, _ := b.tree.LongestPrefix(request)

--- a/handlers.go
+++ b/handlers.go
@@ -20,6 +20,6 @@ func (b *Bot) Serve(msg *Message) {
 	_, value, _ := b.tree.LongestPrefix(request)
 
 	if endpoint, ok := value.(Handler); ok {
-		endpoint(Context{b, msg})
+		go endpoint(Context{b, msg})
 	}
 }


### PR DESCRIPTION
This is my take on serve-and-handle API, which I think we can introduce effortlessly. It doesn't brake any existing API. It also uses radix tree matching for path serving. Here's the sample of proposed API:

```go
bot, err := telebot.NewBot(os.Getenv("BOT_TOKEN"))
if err != nil {
	log.Fatalln(err)
}

bot.Handle("/start", func (c telebot.Context) {
	b, m := c.Bot, c.Message

	b.SendMessage(m.Sender, "Hello!", nil)
})

messages := make(chan telebot.Message, 100)
bot.Listen(messages, 1*time.Second)

for message := range messages {
	bot.Serve(&message)
}
```