### PR TITLE
Fixes a nil pointer dereference

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -190,9 +190,9 @@ func (b *Bot) incomingUpdate(upd *Update) {
 			return
 		}
 
-		// OnAddedToGrop
-		wasAdded := m.UserJoined.ID == b.Me.ID ||
-			m.UsersJoined != nil && isUserInList(b.Me, m.UsersJoined)
+		// OnAddedToGroup
+		wasAdded := (m.UserJoined != nil && m.UserJoined.ID == b.Me.ID) ||
+			(m.UsersJoined != nil && isUserInList(b.Me, m.UsersJoined))
 		if m.GroupCreated || m.SuperGroupCreated || wasAdded {
 			b.handle(OnAddedToGroup, m)
 			return


### PR DESCRIPTION
First time using telebot, I've added a handle to the `OnAddedToGroup` event:

	b.Handle(tb.OnAddedToGroup, func(m *tb.Message) {
		fmt.Printf("%+v\n", m)
	})

and I get a nil pointer dereference error when I create and new group in Telegram with me and the bot. It looks like there is a missing `!= nil` check that this PRs fixes.