### PR TITLE
[BUGFIX] Fixed could not send message to private channel

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -1046,6 +1046,11 @@ func (b *Bot) ChatByID(id string) (*Chat, error) {
 		return nil, errors.Errorf("api error: %s", resp.Description)
 	}
 
+	if resp.Result.Type == ChatChannel && resp.Result.Username != "" {
+		//Channel is Private
+		resp.Result.Type = ChatChannelPrivate
+	}
+
 	return resp.Result, nil
 }
 

--- a/telebot.go
+++ b/telebot.go
@@ -128,10 +128,11 @@ const (
 type ChatType string
 
 const (
-	ChatPrivate    ChatType = "private"
-	ChatGroup      ChatType = "group"
-	ChatSuperGroup ChatType = "supergroup"
-	ChatChannel    ChatType = "channel"
+	ChatPrivate        ChatType = "private"
+	ChatGroup          ChatType = "group"
+	ChatSuperGroup     ChatType = "supergroup"
+	ChatChannel        ChatType = "channel"
+	ChatChannelPrivate ChatType = "privatechannel"
 )
 
 // MemberStatus is one's chat status


### PR DESCRIPTION
Sorry for poor English.
I was developing my bot which will send messages to private channels(where it is admin).
I edit _ChatByID_ which now check if the Chat has an username(which is the public link).
If the username is present the channel is public, if not it is private.

I also added the _ChatChannelPrivate_ which is used instead of _ChatChannel_ when channel is private.
I'am not sure if it is 100% correct but it works for me 😄