### PR TITLE
Added setting for Proxy using.

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -69,7 +69,7 @@ type Settings struct {
 	// on any panics recovered from endpoint handlers.
 	Reporter func(error)
 
-	// Proxy is a full address to redirect every request into.
+	// Proxy is a full address to use as gateway for requests.
 	Proxy string
 }
 


### PR DESCRIPTION
This setting allows to set a Proxy string for the bot to use. 

This way, on creating the bot I can add it like:
```go
b, err := tb.NewBot(tb.Settings{
	Token:  "myt0k3n",
        ...
	Proxy:  "http://proxyhost:port",
})
```

And behind, it will create a client with a transport using the proxy as `client.Post()`. If Proxy were not defined, usual `http.Post()` would be used.

Similar implementation could be used for Bot.sendFiles(). But I haven't had time to try and test an example of those, so it's pending.
