### PR TITLE
Set a unique string ID for each result in inline query Answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ b.Handle(tb.OnQuery, func(q *tb.Query) {
 		}
 
 		results[i] = result
+		results[i].SetResultID(strconv.Itoa(i)) // It's needed to set a unique string ID for each result
 	}
 
 	err := b.Answer(q, &tb.QueryResponse{


### PR DESCRIPTION
It's needed to set a unique string ID for each result in inline query Answer. Otherwise you get an

```
api error: Bad request: RESULT_ID_DUPLICATE
```