### PR TITLE
[WIP] Add io.Reader support for File

### DIFF
--- a/file.go
+++ b/file.go
@@ -1,6 +1,7 @@
 package telebot
 
 import (
+	"io"
 	"os"
 )
 
@@ -17,6 +18,9 @@ type File struct {
 
 	// file on the internet
 	FileURL string `json:"file_url"`
+
+	// raw io.Reader
+	Reader io.Reader
 }
 
 // FromDisk constructs a new local (on-disk) file object.
@@ -43,6 +47,15 @@ func FromDisk(filename string) File {
 //
 func FromURL(url string) File {
 	return File{FileURL: url}
+}
+
+// FromReader constructs a new file from io.Reader.
+//
+//	b := bytes.NewBuffer([]byte("string"))
+//	buff := &tb.Document{File: tb.FromReader(b)}
+//
+func FromReader(f io.Reader) File {
+	return File{Reader: f}
 }
 
 func (f *File) stealRef(g *File) {


### PR DESCRIPTION
Related issue: #137 

Here's my try to add `io.Reader` passing support to upload files from it. 

Basically what I've done is [similar to what](https://github.com/tucnak/telebot/issues/137#issuecomment-422202504) @stek29 proposed, except that I'm not really into `interface{}` type of things :) I tried to make my changes as backward-compatible as possible.

## Changes

* `tb.File` got new field `Reader` that can be assigned with `io.Reader`.
* The `tb.FromReader(io.Reader) File` method was added by analogy with other file source types: `tb.FromDisk()`, `tb.FromURL()`.

## Rough edges

I don't really get `webhook.go` certificates part (I don't use them), so please validate this code if you have an idea.

Please check this out and let me know if anything breaks.

Cheers