### PR TITLE
Add Custom API URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+/.idea

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ import (
 func main() {
 	b, err := tb.NewBot(tb.Settings{
 		Token:  "TOKEN_HERE",
+		// You can also set custom API URL. If field is empty it equals to "https://api.telegram.org"
+		URL: "http://195.129.111.17:8012",
 		Poller: &tb.LongPoller{Timeout: 10 * time.Second},
 	})
 

--- a/api.go
+++ b/api.go
@@ -19,7 +19,7 @@ import (
 
 // Raw lets you call any method of Bot API manually.
 func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
-	url := fmt.Sprintf("https://api.telegram.org/bot%s/%s", b.Token, method)
+	url := fmt.Sprintf("%s/bot%s/%s", b.URL, b.Token, method)
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
@@ -118,7 +118,7 @@ func (b *Bot) sendFiles(
 		return nil, wrapSystem(err)
 	}
 
-	url := fmt.Sprintf("https://api.telegram.org/bot%s/%s", b.Token, method)
+	url := fmt.Sprintf("%s/bot%s/%s", b.URL, b.Token, method)
 	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
 		return nil, wrapSystem(err)

--- a/bot.go
+++ b/bot.go
@@ -25,8 +25,13 @@ func NewBot(pref Settings) (*Bot, error) {
 		client = http.DefaultClient
 	}
 
+	if pref.URL == "" {
+		pref.URL = DefaultApiURL
+	}
+
 	bot := &Bot{
 		Token:   pref.Token,
+		URL:     pref.URL,
 		Updates: make(chan Update, pref.Updates),
 		Poller:  pref.Poller,
 
@@ -49,6 +54,7 @@ func NewBot(pref Settings) (*Bot, error) {
 type Bot struct {
 	Me      *User
 	Token   string
+	URL     string
 	Updates chan Update
 	Poller  Poller
 
@@ -61,6 +67,9 @@ type Bot struct {
 // Settings represents a utility struct for passing certain
 // properties of a bot around and is required to make bots.
 type Settings struct {
+	// Telegram API Url
+	URL string
+
 	// Telegram token
 	Token string
 
@@ -825,8 +834,8 @@ func (b *Bot) Download(f *File, localFilename string) error {
 		return err
 	}
 
-	url := fmt.Sprintf("https://api.telegram.org/file/bot%s/%s",
-		b.Token, g.FilePath)
+	url := fmt.Sprintf("%s/file/bot%s/%s",
+		b.URL, b.Token, g.FilePath)
 
 	out, err := os.Create(localFilename)
 	if err != nil {
@@ -1152,5 +1161,5 @@ func (b *Bot) FileURLByID(fileID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return "https://api.telegram.org/file/bot" + b.Token + "/" + f.FilePath, nil
+	return fmt.Sprintf("%s/file/bot%s/%s", b.URL, b.Token, f.FilePath), nil
 }

--- a/telebot.go
+++ b/telebot.go
@@ -158,3 +158,5 @@ const (
 	FeatureMouth    MaskFeature = "mouth"
 	FeatureChin     MaskFeature = "chin"
 )
+
+const DefaultApiURL = "https://api.telegram.org"

--- a/telebot_test.go
+++ b/telebot_test.go
@@ -58,3 +58,25 @@ func TestFile(t *testing.T) {
 		t.Fatal("File doesn't preserve its original filename.")
 	}
 }
+
+func TestCustomURL(t *testing.T) {
+	token := os.Getenv("TELEBOT_SECRET")
+	if token == "" {
+		fmt.Println("ERROR: " +
+			"In order to test telebot functionality, you need to set up " +
+			"TELEBOT_SECRET environmental variable, which represents an API " +
+			"key to a Telegram bot.\n")
+		t.Fatal("Could't find TELEBOT_SECRET, aborting.")
+	}
+
+	customURL := "http://api.telegram.org"
+
+	bot, err := NewBot(Settings{Token: token, URL: customURL})
+	if err != nil {
+		t.Fatal("couldn't create bot:", err)
+	}
+
+	if bot.URL != customURL {
+		t.Fatal("custom api url is not set")
+	}
+}


### PR DESCRIPTION
I think it can be useful in some situations. For example in Russia Telegram DNS is blocked by government. With custom URL we can run HTTP proxy outside Russia and connect though this proxy to API.