### PR TITLE
Send thumbnails (but not in albums)

### DIFF
--- a/api.go
+++ b/api.go
@@ -143,14 +143,19 @@ func (b *Bot) sendFiles(
 	return json, nil
 }
 
-func (b *Bot) sendObject(f *File, what string, params map[string]string) (*Message, error) {
+func (b *Bot) sendObject(f *File, what string, params map[string]string, files map[string]File) (*Message, error) {
 	sendWhat := "send" + strings.Title(what)
 
 	if what == "videoNote" {
 		what = "video_note"
 	}
 
-	respJSON, err := b.sendFiles(sendWhat, map[string]File{what: *f}, params)
+	sendFiles := map[string]File{what: *f}
+	for k, v := range files {
+		sendFiles[k] = v
+	}
+
+	respJSON, err := b.sendFiles(sendWhat, sendFiles, params)
 	if err != nil {
 		return nil, err
 	}

--- a/sendable.go
+++ b/sendable.go
@@ -30,7 +30,7 @@ func (p *Photo) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 
 	embedSendOptions(params, opt)
 
-	msg, err := b.sendObject(&p.File, "photo", params)
+	msg, err := b.sendObject(&p.File, "photo", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (a *Audio) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 
 	embedSendOptions(params, opt)
 
-	msg, err := b.sendObject(&a.File, "audio", params)
+	msg, err := b.sendObject(&a.File, "audio", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -70,9 +70,8 @@ func (a *Audio) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 // Send delivers media through bot b to recipient.
 func (d *Document) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	params := map[string]string{
-		"chat_id":   to.Recipient(),
-		"caption":   d.Caption,
-		"file_name": d.FileName,
+		"chat_id": to.Recipient(),
+		"caption": d.Caption,
 	}
 
 	if d.FileSize != 0 {
@@ -81,7 +80,7 @@ func (d *Document) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error
 
 	embedSendOptions(params, opt)
 
-	msg, err := b.sendObject(&d.File, "document", params)
+	msg, err := b.sendObject(&d.File, "document", params, thumbnailToFilemap(d.Thumbnail))
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +98,7 @@ func (s *Sticker) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error)
 	}
 	embedSendOptions(params, opt)
 
-	msg, err := b.sendObject(&s.File, "sticker", params)
+	msg, err := b.sendObject(&s.File, "sticker", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +131,7 @@ func (v *Video) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 
 	embedSendOptions(params, opt)
 
-	msg, err := b.sendObject(&v.File, "video", params)
+	msg, err := b.sendObject(&v.File, "video", params, thumbnailToFilemap(v.Thumbnail))
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +163,7 @@ func (v *Voice) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 
 	embedSendOptions(params, opt)
 
-	msg, err := b.sendObject(&v.File, "voice", params)
+	msg, err := b.sendObject(&v.File, "voice", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +189,7 @@ func (v *VideoNote) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, erro
 
 	embedSendOptions(params, opt)
 
-	msg, err := b.sendObject(&v.File, "videoNote", params)
+	msg, err := b.sendObject(&v.File, "videoNote", params, thumbnailToFilemap(v.Thumbnail))
 	if err != nil {
 		return nil, err
 	}

--- a/util.go
+++ b/util.go
@@ -207,3 +207,10 @@ func embedRights(p map[string]string, prv Rights) {
 	jsonRepr, _ := json.Marshal(prv)
 	json.Unmarshal(jsonRepr, &p)
 }
+
+func thumbnailToFilemap(thumb *Photo) map[string]File {
+	if thumb != nil {
+		return map[string]File{"thumb": thumb.File}
+	}
+	return nil
+}


### PR DESCRIPTION
As it turns out, TG only processes thumbnails if they're uploaded as multipart with field name being `thumb`.

Sending thumbnails in albums is still a mystery.