### PR TITLE
Replace Telegram markdown characters

### DIFF
--- a/util.go
+++ b/util.go
@@ -25,7 +25,7 @@ func (b *Bot) deferDebug() {
 }
 
 func (b *Bot) sendText(to Recipient, text string, opt *SendOptions) (*Message, error) {
-	if opt.ParseMode == ModeMarkdown {
+	if opt != nil && opt.ParseMode == ModeMarkdown {
 		text = escapeMarkdownChar(text)
 	}
 

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package telebot
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -24,6 +25,10 @@ func (b *Bot) deferDebug() {
 }
 
 func (b *Bot) sendText(to Recipient, text string, opt *SendOptions) (*Message, error) {
+	if opt.ParseMode == ModeMarkdown {
+		text = escapeMarkdownChar(text)
+	}
+
 	params := map[string]string{
 		"chat_id": to.Recipient(),
 		"text":    text,
@@ -36,6 +41,11 @@ func (b *Bot) sendText(to Recipient, text string, opt *SendOptions) (*Message, e
 	}
 
 	return extractMsgResponse(respJSON)
+}
+
+func escapeMarkdownChar(s string) string {
+	replacer := strings.NewReplacer("*", "\\*", "_", "\\_", "[", "\\[", "`", "\\`")
+	return replacer.Replace(s)
 }
 
 func wrapSystem(err error) error {


### PR DESCRIPTION
See Issue #191 

> Telegram doesn't escape the markdown characters, which might somehow cause the problem. And rather than escape these characters before call the `Send` or `Reply` functions, perhaps it's more elegant to place it inside the telebot and call when the `telebot.ModeMarkdown` is set.