### PR TITLE
fix ChatChannel.

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -34,6 +34,10 @@ type Chat struct {
 
 // Recipient returns chat ID (see Recipient interface).
 func (c *Chat) Recipient() string {
+	switch c.Type {
+	case ChatChannel:
+		return c.Username
+	}
 	return strconv.FormatInt(c.ID, 10)
 }
 


### PR DESCRIPTION
When you want to send something to the channel, just like this:
```
bot.Send(&tb.Chat{Username: "@channel_name",Type:tb.ChatChannel}, "text")
```

And I don't know other `Type` how to set, I think them doesn't work too.