### PR TITLE
Fixes last offset problem in getUpdates.

### DIFF
--- a/api.go
+++ b/api.go
@@ -193,6 +193,9 @@ func (b *Bot) getUpdates(offset int, timeout time.Duration) (upd []Update, err e
 		"offset":  strconv.Itoa(offset),
 		"timeout": strconv.Itoa(int(timeout / time.Second)),
 	}
+	if offset != 0 {
+		params["offset"] = strconv.Itoa(offset)
+	}
 	updatesJSON, errCommand := b.Raw("getUpdates", params)
 	if errCommand != nil {
 		err = errCommand


### PR DESCRIPTION
I try it with another messenger with same as telegram API and it takes last update repetitively so bot responses many times to one single update. I can fix it with removing offset from getUpdates params when it is zero. Telegram python SDK dose the same things with offset.