### PR TITLE
Avoid using fmt.Sprintf for better performance

### DIFF
--- a/api.go
+++ b/api.go
@@ -3,7 +3,6 @@ package telebot
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -19,7 +18,7 @@ import (
 
 // Raw lets you call any method of Bot API manually.
 func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
-	url := fmt.Sprintf("%s/bot%s/%s", b.URL, b.Token, method)
+	url := b.URL+ "/bot" + b.Token+"/"+ method
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
@@ -118,7 +117,7 @@ func (b *Bot) sendFiles(
 		return nil, wrapSystem(err)
 	}
 
-	url := fmt.Sprintf("%s/bot%s/%s", b.URL, b.Token, method)
+	url := b.URL+ "/bot" + b.Token+"/"+ method
 	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
 		return nil, wrapSystem(err)

--- a/bot.go
+++ b/bot.go
@@ -545,7 +545,7 @@ func (b *Bot) SendAlbum(to Recipient, a Album, options ...interface{}) ([]Messag
 		} else if f.FileURL != "" {
 			mediaRepr = f.FileURL
 		} else if f.OnDisk() || f.FileReader != nil {
-			mediaRepr = fmt.Sprintf("attach://%d", i)
+			mediaRepr = "attach://" + strconv.Itoa(i)
 			files[strconv.Itoa(i)] = *f
 		} else {
 			return nil, errors.Errorf(
@@ -1041,8 +1041,7 @@ func (b *Bot) GetFile(file *File) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	url := fmt.Sprintf("%s/file/bot%s/%s",
-		b.URL, b.Token, f.FilePath)
+	url := b.URL + "/file/bot" + b.Token + "/"+ f.FilePath
 
 	resp, err := http.Get(url)
 	if err != nil {
@@ -1062,7 +1061,7 @@ func (b *Bot) StopLiveLocation(message Editable, options ...interface{}) (*Messa
 	messageID, chatID := message.MessageSig()
 
 	params := map[string]string{
-		"chat_id":    fmt.Sprintf("%d", chatID),
+		"chat_id":    strconv.FormatInt(chatID, 10),
 		"message_id": messageID,
 	}
 
@@ -1355,7 +1354,7 @@ func (b *Bot) FileURLByID(fileID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/file/bot%s/%s", b.URL, b.Token, f.FilePath), nil
+	return b.URL + "/file/bot" + b.Token + "/"+ f.FilePath, nil
 }
 
 // UploadStickerFile returns uploaded File on success.

--- a/sendable.go
+++ b/sendable.go
@@ -214,7 +214,7 @@ func (x *Location) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error
 		"chat_id":     to.Recipient(),
 		"latitude":    fmt.Sprintf("%f", x.Lat),
 		"longitude":   fmt.Sprintf("%f", x.Lng),
-		"live_period": fmt.Sprintf("%d", x.LivePeriod),
+		"live_period": strconv.Itoa(x.LivePeriod),
 	}
 	embedSendOptions(params, opt)
 

--- a/webhook.go
+++ b/webhook.go
@@ -73,13 +73,13 @@ func (h *Webhook) getFiles() map[string]File {
 func (h *Webhook) getParams() map[string]string {
 	param := make(map[string]string)
 	if h.TLS != nil {
-		param["url"] = fmt.Sprintf("https://%s", h.Listen)
+		param["url"] = "https://" + h.Listen
 	} else {
 		// this will not work with telegram, they want TLS
 		// but i allow this because telegram will send an error
 		// when you register this hook. in their docs they write
 		// that port 80/http is allowed ...
-		param["url"] = fmt.Sprintf("http://%s", h.Listen)
+		param["url"] = "http://" + h.Listen
 	}
 	if h.Endpoint != nil {
 		param["url"] = h.Endpoint.PublicURL


### PR DESCRIPTION
Hello!

Firstly, let me thank you for developing such a convenient library. I use it for [telego](https://github.com/mitinarseny/telego) and other projects of mine. 

Recently, I've noticed that [telebot](https://github.com/tucnak/telebot) uses [`fmt.Sprintf`](https://golang.org/pkg/fmt/#Sprintf) function, when it is possible to jut concatenate strings using `+`. This would badly affect the speed of the package since `fmt.Sprintf` is [slower](https://dev.to/pmalhaire/concatenate-strings-in-golang-a-quick-benchmark-4ahh) than `+`.

So here is a PR that is intended to slightly increase performance of this excellent package.