### PR TITLE
Implement missed API features

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -62,10 +62,11 @@ type InlineButton struct {
 	// It will be used as a callback endpoint.
 	Unique string `json:"unique,omitempty"`
 
-	Text        string `json:"text"`
-	URL         string `json:"url,omitempty"`
-	Data        string `json:"callback_data,omitempty"`
-	InlineQuery string `json:"switch_inline_query,omitempty"`
+	Text            string `json:"text"`
+	URL             string `json:"url,omitempty"`
+	Data            string `json:"callback_data,omitempty"`
+	InlineQuery     string `json:"switch_inline_query,omitempty"`
+	InlineQueryChat string `json:"switch_inline_query_current_chat"`
 
 	Action func(*Callback) `json:"-"`
 }


### PR DESCRIPTION
### EditReplyMarkup
Wrapper for [editMessageReplyMarkup](https://core.telegram.org/bots/api#editmessagereplymarkup) method. Use EditReplyMarkup if you don't want to care about text of the message, you just need to change an inline keyboard.

### InlineButton
I added `switch_inline_query_current_chat` field to InlineButton struct. Note, that you don't need `omitempty` in json tag. If you pass other parameter like `data`, `url` or `switch_inline_query`, Telegram API ignores `switch_inline_query_current_chat` (I hope so). So it won't cause any conflicts, but will be very useful if you don't want to insert any text in user's input field.