### PR TITLE
Add setters for ResultBase

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -65,6 +65,8 @@ type QueryResponse struct {
 type Result interface {
 	ResultID() string
 	SetResultID(string)
+	SetContent(InputMessageContent)
+	SetReplyMarkup([][]InlineButton)
 	Process()
 }
 

--- a/inline_types.go
+++ b/inline_types.go
@@ -26,6 +26,16 @@ func (r *ResultBase) SetResultID(id string) {
 	r.ID = id
 }
 
+// SetContent sets ResultBase.Content.
+func (r *ResultBase) SetContent(content InputMessageContent) {
+	r.Content = &content
+}
+
+// SetReplyMarkup sets ResultBase.ReplyMarkup.
+func (r *ResultBase) SetReplyMarkup(keyboard [][]InlineButton) {
+	r.ReplyMarkup = &InlineKeyboardMarkup{InlineKeyboard: keyboard}
+}
+
 func (r *ResultBase) Process() {
 	if r.ReplyMarkup != nil {
 		processButtons(r.ReplyMarkup.InlineKeyboard)


### PR DESCRIPTION
It's a bit confusing, when you want to pass custom `Content` to your result (also see #178). I think `ResultBase` don't need pointer to `InputMessageContent`, which is already an interface. Additional setters can solve this problem. I also added `SetReplyMarkup `setter, so now any interaction with `ResultBase` is completely hided.

Example:
```go
// Instead of:
result := &tb.ArticleResult{
        ResultBase: tb.ResultBase{
                Content: new(tb.InputMessageContent)
        },
}
*result.Content = &tb.InputTextMessageContent{
	Text: "Some text",
}

// You can do this:
result.SetContent(&tb.InputTextMessageContent{
	Text: "Some text",
})
```