### PR TITLE
Media objects improvements

### DIFF
--- a/media.go
+++ b/media.go
@@ -83,6 +83,7 @@ type Audio struct {
 	Title     string `json:"title,omitempty"`
 	Performer string `json:"performer,omitempty"`
 	MIME      string `json:"mime_type,omitempty"`
+	FileName  string `json:"file_name,omitempty"`
 }
 
 // MediaFile returns &Audio.File
@@ -95,13 +96,11 @@ func (a *Audio) MediaFile() *File {
 type Document struct {
 	File
 
-	// Original filename as defined by sender.
-	FileName string `json:"file_name"`
-
 	// (Optional)
 	Thumbnail *Photo `json:"thumb,omitempty"`
 	Caption   string `json:"caption,omitempty"`
 	MIME      string `json:"mime_type"`
+	FileName  string `json:"file_name,omitempty"`
 }
 
 // MediaFile returns &Document.File
@@ -123,6 +122,7 @@ type Video struct {
 	Thumbnail         *Photo `json:"thumb,omitempty"`
 	SupportsStreaming bool   `json:"supports_streaming,omitempty"`
 	MIME              string `json:"mime_type,omitempty"`
+	FileName          string `json:"file_name,omitempty"`
 }
 
 // MediaFile returns &Video.File

--- a/sendable.go
+++ b/sendable.go
@@ -38,6 +38,7 @@ func (p *Photo) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 
 	msg.Photo.File.stealRef(&p.File)
 	*p = *msg.Photo
+	p.Caption = msg.Caption
 
 	return msg, nil
 }
@@ -66,6 +67,7 @@ func (a *Audio) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	if msg.Audio != nil {
 		msg.Audio.File.stealRef(&a.File)
 		*a = *msg.Audio
+		a.Caption = msg.Caption
 	}
 
 	if msg.Document != nil {
@@ -97,6 +99,7 @@ func (d *Document) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error
 
 	msg.Document.File.stealRef(&d.File)
 	*d = *msg.Document
+	d.Caption = msg.Caption
 
 	return msg, nil
 }
@@ -150,6 +153,7 @@ func (v *Video) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	if vid := msg.Video; vid != nil {
 		vid.File.stealRef(&v.File)
 		*v = *vid
+		v.Caption = msg.Caption
 	} else if doc := msg.Document; doc != nil {
 		// If video has no sound, Telegram can turn it into Document (GIF)
 		doc.File.stealRef(&v.File)

--- a/sendable.go
+++ b/sendable.go
@@ -49,6 +49,7 @@ func (a *Audio) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 		"caption":   a.Caption,
 		"performer": a.Performer,
 		"title":     a.Title,
+		"file_name": a.FileName,
 	}
 
 	if a.Duration != 0 {
@@ -78,8 +79,9 @@ func (a *Audio) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 // Send delivers media through bot b to recipient.
 func (d *Document) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	params := map[string]string{
-		"chat_id": to.Recipient(),
-		"caption": d.Caption,
+		"chat_id":   to.Recipient(),
+		"caption":   d.Caption,
+		"file_name": d.FileName,
 	}
 
 	if d.FileSize != 0 {
@@ -120,8 +122,9 @@ func (s *Sticker) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error)
 // Send delivers media through bot b to recipient.
 func (v *Video) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	params := map[string]string{
-		"chat_id": to.Recipient(),
-		"caption": v.Caption,
+		"chat_id":   to.Recipient(),
+		"caption":   v.Caption,
+		"file_name": v.FileName,
 	}
 
 	if v.Duration != 0 {


### PR DESCRIPTION
Related to #203.

### File name
Now you can pass your custom file name to an audio, video or document. It's very helpful feature when you work with files. A commit changes `addFileToWriter`, so I also refactor the code a bit to make it good-looking.

### Caption
Another bug was related to captions. When you send any type of media, its caption disappears in your original object. It happens after `stealRef` section, where is value of receiver sets to returned message's media. But actual caption is storing in the message, not media. _It's better to check caption-related changes one more time, since I hadn't enough time to test it perfectly._