### PR TITLE
Callback's inline message

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -312,8 +312,13 @@ func (b *Bot) incomingUpdate(upd *Update) {
 
 	if upd.Callback != nil {
 		if upd.Callback.Data != "" {
-			data := upd.Callback.Data
+			if upd.Callback.MessageID != "" {
+				upd.Callback.Message = &Message{
+					InlineID: upd.Callback.MessageID,
+				}
+			}
 
+			data := upd.Callback.Data
 			if data[0] == '\f' {
 				match := cbackRx.FindAllStringSubmatch(data, -1)
 

--- a/callbacks.go
+++ b/callbacks.go
@@ -27,6 +27,11 @@ type Callback struct {
 	Data string `json:"data"`
 }
 
+// IsInline says whether message is an inline message.
+func (c *Callback) IsInline() bool {
+	return c.MessageID != ""
+}
+
 // CallbackResponse builds a response to a Callback query.
 //
 // See also: https://core.telegram.org/bots/api#answerCallbackQuery

--- a/message.go
+++ b/message.go
@@ -9,6 +9,8 @@ import (
 type Message struct {
 	ID int `json:"message_id"`
 
+	InlineID string `json:"-"`
+
 	// For message sent to channels, Sender will be nil
 	Sender *User `json:"from"`
 
@@ -205,6 +207,9 @@ type MessageEntity struct {
 
 // MessageSig satisfies Editable interface (see Editable.)
 func (m *Message) MessageSig() (string, int64) {
+	if m.InlineID != "" {
+		return m.InlineID, 0
+	}
 	return strconv.Itoa(m.ID), m.Chat.ID
 }
 


### PR DESCRIPTION
This branch allows to call `Edit`, `EditCaption`, ... methods with inline messages. I added helper field `InlineID` to `Message` struct, which indicates that the message is sent by inline mode. Extended `MessageSig` will return this id with zero `chat_id`.

Inline message was handled in edit functions like so:
```go
// If inline message.
if chatID == 0 {
	params["inline_message_id"] = messageID
} else {
	params["chat_id"] = strconv.FormatInt(chatID, 10)
	params["message_id"] = messageID
}
```

..but there wasn't any built-in interface that represents inline message with valid `MessageSig` implementation.

And now, you can do something like this with no problems:
```go
func OnCallback(c *tb.Callback) {
    b.Edit(c, "new text") // even if it's inline message
}
```

I also added helper function `IsInline` for `Callback` type.