### PR TITLE
Add login_url field support to InlineButton

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -1,5 +1,7 @@
 package telebot
 
+import "encoding/json"
+
 // CallbackEndpoint is an interface any element capable
 // of responding to a callback `\f<unique>`.
 type CallbackEndpoint interface {
@@ -72,6 +74,7 @@ type InlineButton struct {
 	Data            string `json:"callback_data,omitempty"`
 	InlineQuery     string `json:"switch_inline_query,omitempty"`
 	InlineQueryChat string `json:"switch_inline_query_current_chat"`
+	Login           *Login `json:"login_url,omitempty"`
 
 	Action func(*Callback) `json:"-"`
 }
@@ -84,4 +87,31 @@ func (t *InlineButton) CallbackUnique() string {
 // CallbackUnique returns KeyboardButton.Text.
 func (t *ReplyButton) CallbackUnique() string {
 	return t.Text
+}
+
+// Login represents a parameter of the inline keyboard button
+// used to automatically authorize a user. Serves as a great replacement
+// for the Telegram Login Widget when the user is coming from Telegram.
+type Login struct {
+	URL         string `json:"url"`
+	Text        string `json:"forward_text,omitempty"`
+	Username    string `json:"bot_username,omitempty"`
+	WriteAccess bool   `json:"request_write_access,omitempty"`
+}
+
+// MarshalJSON implements Marshaler interface.
+// It needed to avoid InlineQueryChat and Login fields conflict.
+// If you have Login field in your button, InlineQueryChat must be skipped.
+func (t *InlineButton) MarshalJSON() ([]byte, error) {
+	type InineButtonJSON InlineButton
+
+	if t.Login != nil {
+		return json.Marshal(struct {
+			InineButtonJSON
+			InlineQueryChat string `json:"switch_inline_query_current_chat,omitempty"`
+		}{
+			InineButtonJSON: InineButtonJSON(*t),
+		})
+	}
+	return json.Marshal(InineButtonJSON(*t))
 }


### PR DESCRIPTION
Issue #232.

```go
// Login represents a parameter of the inline keyboard button
// used to automatically authorize a user. Serves as a great replacement
// for the Telegram Login Widget when the user is coming from Telegram.
type Login struct {
	URL         string `json:"url"`
	Text        string `json:"forward_text,omitempty"`
	Username    string `json:"bot_username,omitempty"`
	WriteAccess bool   `json:"request_write_access,omitempty"`
}
```

Also I had to implement custom `MarshalJSON` for `InlineButton` and I'll explain why. `InlineQueryChat` must not have `omitempty` tag and it's very important! 

There is option in Bot API to leave `switch_inline_query_current_chat` empty, so opened inline-mode also will be empty, or with specified, through BotFather, placeholder. `omitempty` flag shows that this field will be removed when it's empty. Making inline query fields as a pointer to string will break backwards compatibility. 

So, I decided that it's better to leave `omitempty` flag only with login_url in the same time (either it's not working together). Other fields like `data` and `url` have higher priority and `switch_inline_query_current_chat` just skips by API. 

I hope my explanations will help a bit to understand why we need all this.