### PR TITLE
Add support parse_mode for albums photo

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -556,13 +556,15 @@ func (b *Bot) SendAlbum(to Recipient, a Album, options ...interface{}) ([]Messag
 		switch y := x.(type) {
 		case *Photo:
 			jsonRepr, _ = json.Marshal(struct {
-				Type    string `json:"type"`
-				Caption string `json:"caption"`
-				Media   string `json:"media"`
+				Type      string    `json:"type"`
+				Media     string    `json:"media"`
+				Caption   string    `json:"caption,omitempty"`
+				ParseMode ParseMode `json:"parse_mode,omitempty"`
 			}{
 				"photo",
-				y.Caption,
 				mediaRepr,
+				y.Caption,
+				y.ParseMode,
 			})
 		case *Video:
 			jsonRepr, _ = json.Marshal(struct {

--- a/media.go
+++ b/media.go
@@ -26,7 +26,8 @@ type Photo struct {
 	Height int `json:"height"`
 
 	// (Optional)
-	Caption string `json:"caption,omitempty"`
+	Caption   string    `json:"caption,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 }
 
 type photoSize struct {


### PR DESCRIPTION
https://core.telegram.org/bots/api#inputmediaphoto
The "parse_mode" option was not processed in the albums photos.
Added "omitempty" for "caption" because it's optional for request.
Fixed.