### PR TITLE
Added elaborate error handling

### DIFF
--- a/api.go
+++ b/api.go
@@ -33,14 +33,12 @@ func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
 	defer resp.Body.Close()
 
 	json, err := ioutil.ReadAll(resp.Body)
-	fmt.Println(string(json))
 	data := apiErrorRx.FindStringSubmatch(string(json))
 	if err != nil {
 		return []byte{}, wrapSystem(err)
 	}
 
 	if data == nil {
-		fmt.Printf("ok!\n")
 		return json, nil
 	}
 

--- a/api.go
+++ b/api.go
@@ -3,6 +3,7 @@ package telebot
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -32,11 +33,88 @@ func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
 	defer resp.Body.Close()
 
 	json, err := ioutil.ReadAll(resp.Body)
+	fmt.Println(string(json))
+	data := apiErrorRx.FindStringSubmatch(string(json))
 	if err != nil {
 		return []byte{}, wrapSystem(err)
 	}
 
+	if data == nil {
+		fmt.Printf("ok!\n")
+		return json, nil
+	}
+
+	description := data[2]
+	code,_ := strconv.Atoi(data[0])
+	switch description{
+	case ErrUnauthorized.ʔ():
+		err = ErrUnauthorized
+	case ErrToForwardNotFound.ʔ():
+		err = ErrToForwardNotFound
+	case ErrToReplyNotFound.ʔ():
+		err = ErrToReplyNotFound
+	case ErrMessageTooLong.ʔ():
+		err = ErrMessageTooLong
+	case ErrBlockedByUsr.ʔ():
+		err = ErrBlockedByUsr
+	case ErrToDeleteNotFound.ʔ():
+		err = ErrToDeleteNotFound
+	case ErrEmptyMessage.ʔ():
+		err = ErrEmptyMessage
+	case ErrEmptyText.ʔ():
+		err = ErrEmptyText
+	case ErrEmptyChatID.ʔ():
+		err = ErrEmptyChatID
+	case ErrNotFoundChat.ʔ():
+		err = ErrNotFoundChat
+	case ErrMessageNotModified.ʔ():
+		err = ErrMessageNotModified
+	case ErrNoRightsToRestrict.ʔ():
+		err = ErrNoRightsToRestrict
+	case ErrNoRightsToSendMsg.ʔ():
+		err = ErrNoRightsToSendMsg
+	case ErrNoRightsToSendPhoto.ʔ():
+		err = ErrNoRightsToSendPhoto
+	case ErrNoRightsToSendStickers.ʔ():
+		err = ErrNoRightsToSendStickers
+	case ErrNoRightsToSendGifs.ʔ():
+		err = ErrNoRightsToSendGifs
+	case ErrNoRightsToDelete.ʔ():
+		err = ErrNoRightsToDelete
+	case ErrKickingChatOwner.ʔ():
+		err = ErrKickingChatOwner
+	case ErrInteractKickedG.ʔ():
+		err = ErrKickingChatOwner
+	case ErrInteractKickedSprG.ʔ():
+		err = ErrInteractKickedSprG
+	case ErrWrongTypeOfContent.ʔ():
+		err = ErrWrongTypeOfContent
+	case ErrCantGetHTTPurlContent.ʔ():
+		err = ErrCantGetHTTPurlContent
+	case ErrWrongRemoteFileID.ʔ():
+		err = ErrWrongRemoteFileID
+	case ErrFileIdTooShort.ʔ():
+		err = ErrFileIdTooShort
+	case ErrWrongRemoteFileIDsymbol.ʔ():
+		err = ErrWrongRemoteFileIDsymbol
+	case ErrWrongFileIdentifier.ʔ():
+		err = ErrWrongFileIdentifier
+	case ErrTooLarge.ʔ():
+		err = ErrTooLarge
+	case ErrWrongPadding.ʔ():
+		err = ErrWrongPadding
+	case ErrImageProcess.ʔ():
+		err = ErrImageProcess
+	case ErrWrongStickerpack.ʔ():
+		err = ErrWrongStickerpack
+	default:
+		err = fmt.Errorf("unknown api error: %s (%d)", description, code)
+	}
+	if err != nil {
+		return []byte{}, err
+	}
 	return json, nil
+
 }
 
 func addFileToWriter(writer *multipart.Writer,

--- a/api.go
+++ b/api.go
@@ -43,8 +43,8 @@ func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
 	}
 
 	description := data[2]
-	code,_ := strconv.Atoi(data[0])
-	switch description{
+	code, _ := strconv.Atoi(data[0])
+	switch description {
 	case ErrUnauthorized.ʔ():
 		err = ErrUnauthorized
 	case ErrToForwardNotFound.ʔ():

--- a/errors.go
+++ b/errors.go
@@ -7,11 +7,10 @@ import (
 )
 
 type ApiError struct {
-	Code 		int
+	Code        int
 	Description string
 
-	message 	string
-
+	message string
 }
 
 func (err *ApiError) ʔ() string {
@@ -28,11 +27,11 @@ func badRequest(description ...string) *ApiError {
 
 func (err *ApiError) Error() string {
 	canonical := err.message
-	if canonical == ""{
+	if canonical == "" {
 		butchered := strings.Split(err.Description, ": ")
-		if len(butchered) == 2{
+		if len(butchered) == 2 {
 			canonical = butchered[1]
-		}else{
+		} else {
 			canonical = err.Description
 		}
 	}
@@ -41,16 +40,16 @@ func (err *ApiError) Error() string {
 
 var (
 	//RegExp
-    apiErrorRx = regexp.MustCompile(`{.+"error_code":(\d+),"description":"(.+)"}`)
+	apiErrorRx = regexp.MustCompile(`{.+"error_code":(\d+),"description":"(.+)"}`)
 
 	//bot creation errors
-	ErrUnauthorized = &ApiError{401,"Unauthorized",""}
+	ErrUnauthorized = &ApiError{401, "Unauthorized", ""}
 
 	// not found etc
 	ErrToForwardNotFound = badRequest("Bad Request: message to forward not found")
 	ErrToReplyNotFound   = badRequest("Bad Request: reply message not found")
 	ErrMessageTooLong    = badRequest("Bad Request: message is too long")
-	ErrBlockedByUsr      = &ApiError{401,"Forbidden: bot was blocked by the user",""}
+	ErrBlockedByUsr      = &ApiError{401, "Forbidden: bot was blocked by the user", ""}
 	ErrToDeleteNotFound  = badRequest("Bad Request: message to delete not found")
 	ErrEmptyMessage      = badRequest("Bad Request: message must be non-empty")
 	//checking
@@ -59,25 +58,24 @@ var (
 	ErrNotFoundChat       = badRequest("Bad Request: chat not found")
 	ErrMessageNotModified = badRequest("Bad Request: message is not modified")
 
-
 	// Rigts Errors
 	ErrNoRightsToRestrict     = badRequest("Bad Request: not enough rights to restrict/unrestrict chat member")
 	ErrNoRightsToSendMsg      = badRequest("Bad Request: have no rights to send a message")
 	ErrNoRightsToSendPhoto    = badRequest("Bad Request: not enough rights to send photos to the chat")
 	ErrNoRightsToSendStickers = badRequest("Bad Request: not enough rights to send stickers to the chat")
-	ErrNoRightsToSendGifs     = badRequest("Bad Request: CHAT_SEND_GIFS_FORBIDDEN","sending GIFS is not allowed in this chat")
+	ErrNoRightsToSendGifs     = badRequest("Bad Request: CHAT_SEND_GIFS_FORBIDDEN", "sending GIFS is not allowed in this chat")
 	ErrNoRightsToDelete       = badRequest("Bad Request: message can't be deleted")
 	ErrKickingChatOwner       = badRequest("Bad Request: can't remove chat owner")
 
 	// Interacting with group/supergroup after being kicked
-	ErrInteractKickedG    = &ApiError{403,"Forbidden: bot was kicked from the group chat",""}
-	ErrInteractKickedSprG = &ApiError{403,"Forbidden: bot was kicked from the supergroup chat",""}
+	ErrInteractKickedG    = &ApiError{403, "Forbidden: bot was kicked from the group chat", ""}
+	ErrInteractKickedSprG = &ApiError{403, "Forbidden: bot was kicked from the supergroup chat", ""}
 
 	// file errors etc
 	ErrWrongTypeOfContent      = badRequest("Bad Request: wrong type of the web page content")
 	ErrCantGetHTTPurlContent   = badRequest("Bad Request: failed to get HTTP URL content")
 	ErrWrongRemoteFileID       = badRequest("Bad Request: wrong remote file id specified: can't unserialize it. Wrong last symbol")
-	ErrFileIdTooShort    	   = badRequest("Bad Request: wrong remote file id specified: Wrong string length")
+	ErrFileIdTooShort          = badRequest("Bad Request: wrong remote file id specified: Wrong string length")
 	ErrWrongRemoteFileIDsymbol = badRequest("Bad Request: wrong remote file id specified: Wrong character in the string")
 	ErrWrongFileIdentifier     = badRequest("Bad Request: wrong file identifier/HTTP URL specified")
 	ErrTooLarge                = badRequest("Request Entity Too Large")
@@ -85,5 +83,5 @@ var (
 	ErrImageProcess            = badRequest("Bad Request: IMAGE_PROCESS_FAILED", "Image process failed")
 
 	// sticker errors
-	ErrWrongStickerpack = badRequest("Bad Request: STICKERSET_INVALID","Stickerset is invalid")
+	ErrWrongStickerpack = badRequest("Bad Request: STICKERSET_INVALID", "Stickerset is invalid")
 )

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,51 @@
+package telebot
+
+type Error struct {
+	ErrorCode string
+}
+
+var (
+	//bot creation errors
+	ErrUnauthorized = &Error{"Unauthorized"}
+
+	// not found etc
+	ErrToForwardNotFound = &Error{"Bad Request: message to forward not found"}
+	ErrToReplyNotFound   = &Error{"Bad Request: reply message not found"}
+	ErrMessageTooLong    = &Error{"Bad Request: message is too long"}
+	ErrBlockedByUsr      = &Error{"Forbidden: bot was blocked by the user"}
+	ErrToDeleteNotFound  = &Error{"Bad Request: message to delete not found"}
+	ErrEmptyMessage      = &Error{"Bad Request: message must be non-empty"}
+	//checking
+	ErrEmptyText          = &Error{"Bad Request: text is empty"}
+	ErrEmptyChatID        = &Error{"Bad Request: chat_id is empty"}
+	ErrNotFoundChat       = &Error{"Bad Request: chat not found"}
+	ErrMessageNotModified = &Error{"Bad Request: message is not modified"}
+	//
+
+	// Rigts Errors
+	ErrNoRightsToRestrict     = &Error{"Bad Request: not enough rights to restrict/unrestrict chat member"}
+	ErrNoRightsToSendMsg      = &Error{"Bad Request: have no rights to send a message"}
+	ErrNoRightsToSendPhoto    = &Error{"Bad Request: not enough rights to send photos to the chat"}
+	ErrNoRightsToSendStickers = &Error{"Bad Request: not enough rights to send stickers to the chat"}
+	ErrNoRightsToSendGifs     = &Error{"Bad Request: CHAT_SEND_GIFS_FORBIDDEN"}
+	ErrNoRightsToDelete       = &Error{"Bad Request: message can't be deleted"}
+	ErrKickingChatOwner       = &Error{"Bad Request: can't remove chat owner"}
+
+	// Interacting with group/supergroup after being kicked
+	ErrInteractKickedG    = &Error{"api error: Forbidden: bot was kicked from the group chat"}
+	ErrInteractKickedSprG = &Error{"Forbidden: bot was kicked from the supergroup chat"}
+
+	// file errors etc
+	ErrWrongTypeOfContent      = &Error{"Bad Request: wrong type of the web page content"}
+	ErrCantGetHTTPurlContent   = &Error{"Bad Request: failed to get HTTP URL content"}
+	ErrWrongRemoteFileID       = &Error{"Bad Request: wrong remote file id specified: can't unserialize it. Wrong last symbol"}
+	ErrWrongRemoteFileIDlen    = &Error{"Bad Request: wrong remote file id specified: Wrong string length"}
+	ErrWrongRemoteFileIDsymbol = &Error{"Bad Request: wrong remote file id specified: Wrong character in the string"}
+	ErrWrongFileIdentifier     = &Error{"Bad Request: wrong file identifier/HTTP URL specified"}
+	ErrTooLarge                = &Error{"Request Entity Too Large"}
+	ErrWrongPadding            = &Error{"Bad Request: wrong remote file id specified: Wrong padding in the string"} // not my
+	ErrImageProcess            = &Error{"Bad Request: IMAGE_PROCESS_FAILED"}
+
+	// sticker errors
+	ErrWrongStickerpack = &Error{"Bad Request: STICKERSET_INVALID"}
+)

--- a/errors.go
+++ b/errors.go
@@ -1,55 +1,89 @@
 package telebot
 
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
 type ApiError struct {
-	ErrorCode string
+	Code 		int
+	Description string
+
+	message 	string
+
+}
+
+func (err *ApiError) ʔ() string {
+	return err.Description
+}
+
+func badRequest(description ...string) *ApiError {
+	if len(description) == 1 {
+		return &ApiError{400, description[0], ""}
+	}
+
+	return &ApiError{400, description[0], description[1]}
 }
 
 func (err *ApiError) Error() string {
-	return err.ErrorCode
+	canonical := err.message
+	if canonical == ""{
+		butchered := strings.Split(err.Description, ": ")
+		if len(butchered) == 2{
+			canonical = butchered[1]
+		}else{
+			canonical = err.Description
+		}
+	}
+	return fmt.Sprintf("api error: %s (%d)", canonical, err.Code)
 }
 
 var (
+	//RegExp
+    apiErrorRx = regexp.MustCompile(`{.+"error_code":(\d+),"description":"(.+)"}`)
+
 	//bot creation errors
-	ErrUnauthorized = &ApiError{"Unauthorized"}
+	ErrUnauthorized = &ApiError{401,"Unauthorized",""}
 
 	// not found etc
-	ErrToForwardNotFound = &ApiError{"Bad Request: message to forward not found"}
-	ErrToReplyNotFound   = &ApiError{"Bad Request: reply message not found"}
-	ErrMessageTooLong    = &ApiError{"Bad Request: message is too long"}
-	ErrBlockedByUsr      = &ApiError{"Forbidden: bot was blocked by the user"}
-	ErrToDeleteNotFound  = &ApiError{"Bad Request: message to delete not found"}
-	ErrEmptyMessage      = &ApiError{"Bad Request: message must be non-empty"}
+	ErrToForwardNotFound = badRequest("Bad Request: message to forward not found")
+	ErrToReplyNotFound   = badRequest("Bad Request: reply message not found")
+	ErrMessageTooLong    = badRequest("Bad Request: message is too long")
+	ErrBlockedByUsr      = &ApiError{401,"Forbidden: bot was blocked by the user",""}
+	ErrToDeleteNotFound  = badRequest("Bad Request: message to delete not found")
+	ErrEmptyMessage      = badRequest("Bad Request: message must be non-empty")
 	//checking
-	ErrEmptyText          = &ApiError{"Bad Request: text is empty"}
-	ErrEmptyChatID        = &ApiError{"Bad Request: chat_id is empty"}
-	ErrNotFoundChat       = &ApiError{"Bad Request: chat not found"}
-	ErrMessageNotModified = &ApiError{"Bad Request: message is not modified"}
-	//
+	ErrEmptyText          = badRequest("Bad Request: text is empty")
+	ErrEmptyChatID        = badRequest("Bad Request: chat_id is empty")
+	ErrNotFoundChat       = badRequest("Bad Request: chat not found")
+	ErrMessageNotModified = badRequest("Bad Request: message is not modified")
+
 
 	// Rigts Errors
-	ErrNoRightsToRestrict     = &ApiError{"Bad Request: not enough rights to restrict/unrestrict chat member"}
-	ErrNoRightsToSendMsg      = &ApiError{"Bad Request: have no rights to send a message"}
-	ErrNoRightsToSendPhoto    = &ApiError{"Bad Request: not enough rights to send photos to the chat"}
-	ErrNoRightsToSendStickers = &ApiError{"Bad Request: not enough rights to send stickers to the chat"}
-	ErrNoRightsToSendGifs     = &ApiError{"Bad Request: CHAT_SEND_GIFS_FORBIDDEN"}
-	ErrNoRightsToDelete       = &ApiError{"Bad Request: message can't be deleted"}
-	ErrKickingChatOwner       = &ApiError{"Bad Request: can't remove chat owner"}
+	ErrNoRightsToRestrict     = badRequest("Bad Request: not enough rights to restrict/unrestrict chat member")
+	ErrNoRightsToSendMsg      = badRequest("Bad Request: have no rights to send a message")
+	ErrNoRightsToSendPhoto    = badRequest("Bad Request: not enough rights to send photos to the chat")
+	ErrNoRightsToSendStickers = badRequest("Bad Request: not enough rights to send stickers to the chat")
+	ErrNoRightsToSendGifs     = badRequest("Bad Request: CHAT_SEND_GIFS_FORBIDDEN","sending GIFS is not allowed in this chat")
+	ErrNoRightsToDelete       = badRequest("Bad Request: message can't be deleted")
+	ErrKickingChatOwner       = badRequest("Bad Request: can't remove chat owner")
 
 	// Interacting with group/supergroup after being kicked
-	ErrInteractKickedG    = &ApiError{"api error: Forbidden: bot was kicked from the group chat"}
-	ErrInteractKickedSprG = &ApiError{"Forbidden: bot was kicked from the supergroup chat"}
+	ErrInteractKickedG    = &ApiError{403,"Forbidden: bot was kicked from the group chat",""}
+	ErrInteractKickedSprG = &ApiError{403,"Forbidden: bot was kicked from the supergroup chat",""}
 
 	// file errors etc
-	ErrWrongTypeOfContent      = &ApiError{"Bad Request: wrong type of the web page content"}
-	ErrCantGetHTTPurlContent   = &ApiError{"Bad Request: failed to get HTTP URL content"}
-	ErrWrongRemoteFileID       = &ApiError{"Bad Request: wrong remote file id specified: can't unserialize it. Wrong last symbol"}
-	ErrWrongRemoteFileIDlen    = &ApiError{"Bad Request: wrong remote file id specified: Wrong string length"}
-	ErrWrongRemoteFileIDsymbol = &ApiError{"Bad Request: wrong remote file id specified: Wrong character in the string"}
-	ErrWrongFileIdentifier     = &ApiError{"Bad Request: wrong file identifier/HTTP URL specified"}
-	ErrTooLarge                = &ApiError{"Request Entity Too Large"}
-	ErrWrongPadding            = &ApiError{"Bad Request: wrong remote file id specified: Wrong padding in the string"} // not my
-	ErrImageProcess            = &ApiError{"Bad Request: IMAGE_PROCESS_FAILED"}
+	ErrWrongTypeOfContent      = badRequest("Bad Request: wrong type of the web page content")
+	ErrCantGetHTTPurlContent   = badRequest("Bad Request: failed to get HTTP URL content")
+	ErrWrongRemoteFileID       = badRequest("Bad Request: wrong remote file id specified: can't unserialize it. Wrong last symbol")
+	ErrFileIdTooShort    	   = badRequest("Bad Request: wrong remote file id specified: Wrong string length")
+	ErrWrongRemoteFileIDsymbol = badRequest("Bad Request: wrong remote file id specified: Wrong character in the string")
+	ErrWrongFileIdentifier     = badRequest("Bad Request: wrong file identifier/HTTP URL specified")
+	ErrTooLarge                = badRequest("Request Entity Too Large")
+	ErrWrongPadding            = badRequest("Bad Request: wrong remote file id specified: Wrong padding in the string") // not my
+	ErrImageProcess            = badRequest("Bad Request: IMAGE_PROCESS_FAILED", "Image process failed")
 
 	// sticker errors
-	ErrWrongStickerpack = &ApiError{"Bad Request: STICKERSET_INVALID"}
+	ErrWrongStickerpack = badRequest("Bad Request: STICKERSET_INVALID","Stickerset is invalid")
 )

--- a/errors.go
+++ b/errors.go
@@ -1,51 +1,55 @@
 package telebot
 
-type Error struct {
+type ApiError struct {
 	ErrorCode string
+}
+
+func (err *ApiError) Error() string {
+	return err.ErrorCode
 }
 
 var (
 	//bot creation errors
-	ErrUnauthorized = &Error{"Unauthorized"}
+	ErrUnauthorized = &ApiError{"Unauthorized"}
 
 	// not found etc
-	ErrToForwardNotFound = &Error{"Bad Request: message to forward not found"}
-	ErrToReplyNotFound   = &Error{"Bad Request: reply message not found"}
-	ErrMessageTooLong    = &Error{"Bad Request: message is too long"}
-	ErrBlockedByUsr      = &Error{"Forbidden: bot was blocked by the user"}
-	ErrToDeleteNotFound  = &Error{"Bad Request: message to delete not found"}
-	ErrEmptyMessage      = &Error{"Bad Request: message must be non-empty"}
+	ErrToForwardNotFound = &ApiError{"Bad Request: message to forward not found"}
+	ErrToReplyNotFound   = &ApiError{"Bad Request: reply message not found"}
+	ErrMessageTooLong    = &ApiError{"Bad Request: message is too long"}
+	ErrBlockedByUsr      = &ApiError{"Forbidden: bot was blocked by the user"}
+	ErrToDeleteNotFound  = &ApiError{"Bad Request: message to delete not found"}
+	ErrEmptyMessage      = &ApiError{"Bad Request: message must be non-empty"}
 	//checking
-	ErrEmptyText          = &Error{"Bad Request: text is empty"}
-	ErrEmptyChatID        = &Error{"Bad Request: chat_id is empty"}
-	ErrNotFoundChat       = &Error{"Bad Request: chat not found"}
-	ErrMessageNotModified = &Error{"Bad Request: message is not modified"}
+	ErrEmptyText          = &ApiError{"Bad Request: text is empty"}
+	ErrEmptyChatID        = &ApiError{"Bad Request: chat_id is empty"}
+	ErrNotFoundChat       = &ApiError{"Bad Request: chat not found"}
+	ErrMessageNotModified = &ApiError{"Bad Request: message is not modified"}
 	//
 
 	// Rigts Errors
-	ErrNoRightsToRestrict     = &Error{"Bad Request: not enough rights to restrict/unrestrict chat member"}
-	ErrNoRightsToSendMsg      = &Error{"Bad Request: have no rights to send a message"}
-	ErrNoRightsToSendPhoto    = &Error{"Bad Request: not enough rights to send photos to the chat"}
-	ErrNoRightsToSendStickers = &Error{"Bad Request: not enough rights to send stickers to the chat"}
-	ErrNoRightsToSendGifs     = &Error{"Bad Request: CHAT_SEND_GIFS_FORBIDDEN"}
-	ErrNoRightsToDelete       = &Error{"Bad Request: message can't be deleted"}
-	ErrKickingChatOwner       = &Error{"Bad Request: can't remove chat owner"}
+	ErrNoRightsToRestrict     = &ApiError{"Bad Request: not enough rights to restrict/unrestrict chat member"}
+	ErrNoRightsToSendMsg      = &ApiError{"Bad Request: have no rights to send a message"}
+	ErrNoRightsToSendPhoto    = &ApiError{"Bad Request: not enough rights to send photos to the chat"}
+	ErrNoRightsToSendStickers = &ApiError{"Bad Request: not enough rights to send stickers to the chat"}
+	ErrNoRightsToSendGifs     = &ApiError{"Bad Request: CHAT_SEND_GIFS_FORBIDDEN"}
+	ErrNoRightsToDelete       = &ApiError{"Bad Request: message can't be deleted"}
+	ErrKickingChatOwner       = &ApiError{"Bad Request: can't remove chat owner"}
 
 	// Interacting with group/supergroup after being kicked
-	ErrInteractKickedG    = &Error{"api error: Forbidden: bot was kicked from the group chat"}
-	ErrInteractKickedSprG = &Error{"Forbidden: bot was kicked from the supergroup chat"}
+	ErrInteractKickedG    = &ApiError{"api error: Forbidden: bot was kicked from the group chat"}
+	ErrInteractKickedSprG = &ApiError{"Forbidden: bot was kicked from the supergroup chat"}
 
 	// file errors etc
-	ErrWrongTypeOfContent      = &Error{"Bad Request: wrong type of the web page content"}
-	ErrCantGetHTTPurlContent   = &Error{"Bad Request: failed to get HTTP URL content"}
-	ErrWrongRemoteFileID       = &Error{"Bad Request: wrong remote file id specified: can't unserialize it. Wrong last symbol"}
-	ErrWrongRemoteFileIDlen    = &Error{"Bad Request: wrong remote file id specified: Wrong string length"}
-	ErrWrongRemoteFileIDsymbol = &Error{"Bad Request: wrong remote file id specified: Wrong character in the string"}
-	ErrWrongFileIdentifier     = &Error{"Bad Request: wrong file identifier/HTTP URL specified"}
-	ErrTooLarge                = &Error{"Request Entity Too Large"}
-	ErrWrongPadding            = &Error{"Bad Request: wrong remote file id specified: Wrong padding in the string"} // not my
-	ErrImageProcess            = &Error{"Bad Request: IMAGE_PROCESS_FAILED"}
+	ErrWrongTypeOfContent      = &ApiError{"Bad Request: wrong type of the web page content"}
+	ErrCantGetHTTPurlContent   = &ApiError{"Bad Request: failed to get HTTP URL content"}
+	ErrWrongRemoteFileID       = &ApiError{"Bad Request: wrong remote file id specified: can't unserialize it. Wrong last symbol"}
+	ErrWrongRemoteFileIDlen    = &ApiError{"Bad Request: wrong remote file id specified: Wrong string length"}
+	ErrWrongRemoteFileIDsymbol = &ApiError{"Bad Request: wrong remote file id specified: Wrong character in the string"}
+	ErrWrongFileIdentifier     = &ApiError{"Bad Request: wrong file identifier/HTTP URL specified"}
+	ErrTooLarge                = &ApiError{"Request Entity Too Large"}
+	ErrWrongPadding            = &ApiError{"Bad Request: wrong remote file id specified: Wrong padding in the string"} // not my
+	ErrImageProcess            = &ApiError{"Bad Request: IMAGE_PROCESS_FAILED"}
 
 	// sticker errors
-	ErrWrongStickerpack = &Error{"Bad Request: STICKERSET_INVALID"}
+	ErrWrongStickerpack = &ApiError{"Bad Request: STICKERSET_INVALID"}
 )


### PR DESCRIPTION
Since there was no error handling in telebot, I found all the possible errors in the Telegram API and put them into a table ([csv](https://gist.github.com/p3nt3st3rPrise/0441ccb956a72ae491dd4a67f676c552)). Here it is: 
![image](https://user-images.githubusercontent.com/17340030/77807987-90c2d080-7081-11ea-8b97-2bdd380220e5.png) 

I've added `ApiError` struct which covers API errors 

Kudos to @tucnak for mentoring me along the way.