### PR TITLE
fix errorRx to match other APIError

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -72,3 +72,17 @@ func TestRaw(t *testing.T) {
 	_, err = b.Raw("testUnknownError", nil)
 	assert.EqualError(t, err, "telegram unknown: unknown error (400)")
 }
+
+func TestExtractOK(t *testing.T) {
+	data := []byte(`{"ok":true}`)
+	assert.Nil(t, extractOk(data))
+
+	data = []byte(`{"ok":true,"result":{}`)
+	assert.Nil(t, extractOk(data))
+
+	data = []byte(`{"ok":false,"error_code":400,"description":"Bad Request: message to edit not found"}`)
+	assert.EqualError(t, extractOk(data), extractOk(data).Error())
+
+	data = []byte(`{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 10","parameters":{"retry_after":10}}`)
+	assert.EqualError(t, extractOk(data), extractOk(data).Error())
+}

--- a/errors.go
+++ b/errors.go
@@ -45,7 +45,7 @@ func NewAPIError(code int, msgs ...string) *APIError {
 	return err
 }
 
-var errorRx = regexp.MustCompile(`{.+"error_code":(\d+),"description":"(.+)"}`)
+var errorRx = regexp.MustCompile(`{.+"error_code":(\d+),"description":"(.+?)".*}`)
 
 var (
 	// General errors


### PR DESCRIPTION
The pattern `{.+"error_code":(\d+),"description":"(.+)"}` can match the result of json:
```json
{"ok":false,"error_code":400,"description":"Bad Request: message to edit not found"}
```

but cannot match the one below:
```json
{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 10","parameters":{"retry_after":10}}
```
So change it to `{.+"error_code":(\d+),"description":"(.+).*"}`, which can prevent the ` nil pointer error ` from happening

https://github.com/tucnak/telebot/blob/319196b8471500baece223be6acfc94a04280226/util.go#L48-L56