### PR TITLE
stickers: update to the latest version of the Telegram API

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -1527,6 +1527,26 @@ func (b *Bot) DeleteStickerFromSet(sticker string) error {
 	return extractOk(data)
 }
 
+// SetStickerSetThumb sets the thumbnail of a sticker set. Animated thumbnails can be set for animated sticker sets only.
+//
+// Thumbnail must be a PNG image, up to 128 kilobytes in size and have width and height exactly 100px,
+// or a TGS animation up to 32 kilobytes in size. Animated sticker set thumbnail can't be uploaded via HTTP URL.
+func (b *Bot) SetStickerSetThumb(to Recipient, s Sticker) error {
+	files := map[string]File{}
+	if s.PNG != nil {
+		files["thumb"] = *s.PNG
+	} else if s.TGS != nil {
+		files["thumb"] = *s.TGS
+	}
+	params := map[string]string{
+		"name":    s.Name,
+		"user_id": to.Recipient(),
+	}
+
+	_, err := b.sendFiles("setStickerSetThumb", files, params)
+	return err
+}
+
 // GetCommands returns the current list of the bot's commands.
 func (b *Bot) GetCommands() ([]Command, error) {
 	data, err := b.Raw("getMyCommands", nil)

--- a/stickers.go
+++ b/stickers.go
@@ -3,22 +3,31 @@ package telebot
 // Sticker object represents a WebP image, so-called sticker.
 type Sticker struct {
 	File
-
-	Width  int `json:"width"`
-	Height int `json:"height"`
-
-	Thumbnail    *Photo        `json:"thumb,omitempty"`
-	Emoji        string        `json:"emoji,omitempty"`
-	SetName      string        `json:"set_name,omitempty"`
-	MaskPosition *MaskPosition `json:"mask_position,omitempty"`
+	Width        int           `json:"width"`
+	Height       int           `json:"height"`
+	Animated     bool          `json:"is_animated"`
+	Thumbnail    *Photo        `json:"thumb"`
+	Emoji        string        `json:"emoji"`
+	Name         string        `json:"name"`
+	SetName      string        `json:"set_name"`
+	PNG          *File         `json:"png_sticker"`
+	TGS          *File         `json:"tgs_file"`
+	Emojis       string        `json:"emojis"`
+	MaskPosition *MaskPosition `json:"mask_position"`
 }
 
 // StickerSet represents a sticker set
 type StickerSet struct {
-	Name          string    `json:"name"`
-	Title         string    `json:"title"`
-	ContainsMasks bool      `json:"contains_masks"`
-	Stickers      []Sticker `json:"stickers"`
+	Name          string        `json:"name"`
+	Title         string        `json:"title"`
+	Animated      bool          `json:"is_animated"`
+	ContainsMasks bool          `json:"contains_masks"`
+	Stickers      []Sticker     `json:"stickers"`
+	Thumbnail     *Photo        `json:"thumb"`
+	PNG           *File         `json:"png_sticker"`
+	TGS           *File         `json:"tgs_file"`
+	Emojis        string        `json:"emojis"`
+	MaskPosition  *MaskPosition `json:"mask_position"`
 }
 
 // MaskPosition describes the position on faces where


### PR DESCRIPTION
There were some sticker updates in Bot API 4.7 and this pull request is affected by changes: updated the structure of Sticker and StickerSet, updated (and broke) the parameters of some functions described in the  https://github.com/tucnak/telebot/commit/8dffb4f3676d54189476fa926714b3fab9b1f7c6

Closes issues #273 