### PR TITLE
errors: fix regular expression

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -45,7 +45,7 @@ func NewAPIError(code int, msgs ...string) *APIError {
 	return err
 }
 
-var errorRx = regexp.MustCompile(`{.+"error_code":(\d+),"description":"(.+)"}`)
+var errorRx = regexp.MustCompile(`{.+"error_code":(\d+),"description":"(.+)".*}`)
 
 var (
 	// General errors

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,18 @@
+package telebot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractOk(t *testing.T) {
+	data := []byte(`{"ok":true,"result":{"foo":"bar"}}`)
+	assert.NoError(t, extractOk(data))
+
+	data = []byte(`{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 8","parameters":{"retry_after":8}}`)
+	assert.Error(t, extractOk(data))
+
+	data = []byte(`{"ok":false,"error_code":400,"description":"Bad Request: reply message not found"}`) // Also check the old format
+	assert.EqualError(t, extractOk(data), ErrToReplyNotFound.Error())
+}


### PR DESCRIPTION
Telegram Bot API now returns an extra field for error responses, such as:

```json
{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 8","parameters":{"retry_after":8}}
```

This means that existing regular expression cannot extract errors normally, so it will cause panic.