### PR TITLE
bot: fix FileURLByID for local Bot API server

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1409,11 +1410,18 @@ func (b *Bot) ChatMemberOf(chat *Chat, user *User) (*ChatMember, error) {
 	return resp.Result, nil
 }
 
-// FileURLByID returns direct url for files using FileId which you can get from File object
+// FileURLByID returns direct url for files using FileID which you can get from
+// File object. It returns a file:/// URL when the target file is on the
+// local disk (it happens if you are using a local Bot API server, see
+// https://core.telegram.org/bots/api#using-a-local-bot-api-server for details).
 func (b *Bot) FileURLByID(fileID string) (string, error) {
 	f, err := b.FileByID(fileID)
 	if err != nil {
 		return "", err
+	}
+
+	if path.IsAbs(f.FilePath) {
+		return "file://" + f.FilePath, nil
 	}
 
 	return b.URL + "/file/bot" + b.Token + "/" + f.FilePath, nil


### PR DESCRIPTION
According to [this](https://core.telegram.org/bots/api#using-a-local-bot-api-server):

> * Receive the absolute local path as a value of the *file_path* field without the need to download the file after a [getFile](https://core.telegram.org/bots/api#getfile) request.

We can assume that the file whose `FilePath` is an absolute path is from the local disk. So, we shouldn't return `http://` URL for it, `file:///` URL is more appropriate.