### PR TITLE
Fix error handling in Nil response case in the send Object

### DIFF
--- a/telebot.go
+++ b/telebot.go
@@ -35,6 +35,7 @@ var (
 	ErrUnsupportedWhat = errors.New("telebot: unsupported what argument")
 	ErrCouldNotUpdate  = errors.New("telebot: could not fetch new updates")
 	ErrTrueResult      = errors.New("telebot: result is True")
+	ErrNilResponse     = errors.New("telebot: result is nil")
 )
 
 const DefaultApiURL = "https://api.telegram.org"

--- a/util.go
+++ b/util.go
@@ -94,6 +94,11 @@ func extractMessage(data []byte) (*Message, error) {
 		}
 		return nil, wrapError(err)
 	}
+
+	if resp.Result == nil {
+		return nil, ErrNilResponse
+	}
+
 	return resp.Result, nil
 }
 


### PR DESCRIPTION
In some cases (I think in the internal error case) `resp.Result` is Nil and the application crashes in the next functions such as Send functions in the Sendable interface.