### PR TITLE
Expose offline settings for Bot

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -45,7 +45,7 @@ func NewBot(pref Settings) (*Bot, error) {
 		client:      client,
 	}
 
-	if pref.offline {
+	if pref.Offline {
 		bot.Me = &User{}
 	} else {
 		user, err := bot.getMe()
@@ -110,8 +110,8 @@ type Settings struct {
 	// HTTP Client used to make requests to telegram api
 	Client *http.Client
 
-	// offline allows to create a bot without network for testing purposes.
-	offline bool
+	// Offline allows to create a bot without network for testing purposes.
+	Offline bool
 }
 
 // Update object represents an incoming update.

--- a/poller_test.go
+++ b/poller_test.go
@@ -35,7 +35,7 @@ func TestMiddlewarePoller(t *testing.T) {
 	var ids []int
 
 	pref := defaultSettings()
-	pref.offline = true
+	pref.Offline = true
 
 	b, err := NewBot(pref)
 	if err != nil {


### PR DESCRIPTION
I want to write integration tests with the bot myself. I don't plan on re-implementing the command routing etc. 
It would be super helpful to use the offline mode for that externally to the project.
These changes allow my tests to pass successfully.
