### PR TITLE
implements voice chat service messages

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -8,20 +8,21 @@ import (
 
 // Rights is a list of privileges available to chat members.
 type Rights struct {
-	CanBeEdited        bool `json:"can_be_edited"`
-	CanChangeInfo      bool `json:"can_change_info"`
-	CanPostMessages    bool `json:"can_post_messages"`
-	CanEditMessages    bool `json:"can_edit_messages"`
-	CanDeleteMessages  bool `json:"can_delete_messages"`
-	CanInviteUsers     bool `json:"can_invite_users"`
-	CanRestrictMembers bool `json:"can_restrict_members"`
-	CanPinMessages     bool `json:"can_pin_messages"`
-	CanPromoteMembers  bool `json:"can_promote_members"`
-	CanSendMessages    bool `json:"can_send_messages"`
-	CanSendMedia       bool `json:"can_send_media_messages"`
-	CanSendPolls       bool `json:"can_send_polls"`
-	CanSendOther       bool `json:"can_send_other_messages"`
-	CanAddPreviews     bool `json:"can_add_web_page_previews"`
+	CanBeEdited         bool `json:"can_be_edited"`
+	CanChangeInfo       bool `json:"can_change_info"`
+	CanPostMessages     bool `json:"can_post_messages"`
+	CanEditMessages     bool `json:"can_edit_messages"`
+	CanDeleteMessages   bool `json:"can_delete_messages"`
+	CanInviteUsers      bool `json:"can_invite_users"`
+	CanRestrictMembers  bool `json:"can_restrict_members"`
+	CanPinMessages      bool `json:"can_pin_messages"`
+	CanPromoteMembers   bool `json:"can_promote_members"`
+	CanSendMessages     bool `json:"can_send_messages"`
+	CanSendMedia        bool `json:"can_send_media_messages"`
+	CanSendPolls        bool `json:"can_send_polls"`
+	CanSendOther        bool `json:"can_send_other_messages"`
+	CanAddPreviews      bool `json:"can_add_web_page_previews"`
+	CanManageVoiceChats bool `json:"can_manage_voice_chats"`
 }
 
 // NoRights is the default Rights{}.
@@ -35,40 +36,42 @@ func NoRights() Rights { return Rights{} }
 //
 func NoRestrictions() Rights {
 	return Rights{
-		CanBeEdited:        true,
-		CanChangeInfo:      false,
-		CanPostMessages:    false,
-		CanEditMessages:    false,
-		CanDeleteMessages:  false,
-		CanInviteUsers:     false,
-		CanRestrictMembers: false,
-		CanPinMessages:     false,
-		CanPromoteMembers:  false,
-		CanSendMessages:    true,
-		CanSendMedia:       true,
-		CanSendPolls:       true,
-		CanSendOther:       true,
-		CanAddPreviews:     true,
+		CanBeEdited:         true,
+		CanChangeInfo:       false,
+		CanPostMessages:     false,
+		CanEditMessages:     false,
+		CanDeleteMessages:   false,
+		CanInviteUsers:      false,
+		CanRestrictMembers:  false,
+		CanPinMessages:      false,
+		CanPromoteMembers:   false,
+		CanSendMessages:     true,
+		CanSendMedia:        true,
+		CanSendPolls:        true,
+		CanSendOther:        true,
+		CanAddPreviews:      true,
+		CanManageVoiceChats: false,
 	}
 }
 
 // AdminRights could be used to promote user to admin.
 func AdminRights() Rights {
 	return Rights{
-		CanBeEdited:        true,
-		CanChangeInfo:      true,
-		CanPostMessages:    true,
-		CanEditMessages:    true,
-		CanDeleteMessages:  true,
-		CanInviteUsers:     true,
-		CanRestrictMembers: true,
-		CanPinMessages:     true,
-		CanPromoteMembers:  true,
-		CanSendMessages:    true,
-		CanSendMedia:       true,
-		CanSendPolls:       true,
-		CanSendOther:       true,
-		CanAddPreviews:     true,
+		CanBeEdited:         true,
+		CanChangeInfo:       true,
+		CanPostMessages:     true,
+		CanEditMessages:     true,
+		CanDeleteMessages:   true,
+		CanInviteUsers:      true,
+		CanRestrictMembers:  true,
+		CanPinMessages:      true,
+		CanPromoteMembers:   true,
+		CanSendMessages:     true,
+		CanSendMedia:        true,
+		CanSendPolls:        true,
+		CanSendOther:        true,
+		CanAddPreviews:      true,
+		CanManageVoiceChats: true,
 	}
 }
 

--- a/bot.go
+++ b/bot.go
@@ -306,6 +306,44 @@ func (b *Bot) ProcessUpdate(upd Update) {
 			return
 		}
 
+		if m.VoiceChatStarted != nil {
+			if handler, ok := b.handlers[OnVoiceChatStarted]; ok {
+				handler, ok := handler.(func(*Message))
+				if !ok {
+					panic("telebot: voice chat started handler is bad")
+				}
+
+				b.runHandler(func() { handler(m) })
+			}
+
+			return
+		}
+
+		if m.VoiceChatEnded != nil {
+			if handler, ok := b.handlers[OnVoiceChatEnded]; ok {
+				handler, ok := handler.(func(*Message))
+				if !ok {
+					panic("telebot: voice chat ended handler is bad")
+				}
+
+				b.runHandler(func() { handler(m) })
+			}
+
+			return
+		}
+
+		if m.VoiceChatPartecipantsInvited != nil {
+			if handler, ok := b.handlers[OnVoiceChatPartecipantsInvited]; ok {
+				handler, ok := handler.(func(*Message))
+				if !ok {
+					panic("telebot: voice chat partecipants invited handler is bad")
+				}
+
+				b.runHandler(func() { handler(m) })
+			}
+
+			return
+		}
 	}
 
 	if upd.EditedMessage != nil {

--- a/message.go
+++ b/message.go
@@ -217,6 +217,15 @@ type Message struct {
 
 	// Inline keyboard attached to the message.
 	ReplyMarkup InlineKeyboardMarkup `json:"reply_markup"`
+
+	// For a service message, a voice chat started in the chat.
+	VoiceChatStarted *VoiceChatStarted `json:"voice_chat_started,omitempty"`
+
+	// For a service message, a voice chat ended in the chat.
+	VoiceChatEnded *VoiceChatEnded `json:"voice_chat_ended,omitempty"`
+
+	// For a service message, some users were invited in the voice chat.
+	VoiceChatPartecipantsInvited *VoiceChatPartecipantsInvited `json:"voice_chat_partecipants_invited,omitempty"`
 }
 
 // MessageEntity object represents "special" parts of text messages,

--- a/telebot.go
+++ b/telebot.go
@@ -119,6 +119,21 @@ const (
 	//
 	// Handler: func(*PollAnswer)
 	OnPollAnswer = "\apoll_answer"
+
+	// Will fire on VoiceChatStarted
+	//
+	// Handler: func(*Message)
+	OnVoiceChatStarted = "\avoice_chat_started"
+
+	// Will fire on VoiceChatEnded
+	//
+	// Handler: func(*Message)
+	OnVoiceChatEnded = "\avoice_chat_ended"
+
+	// Will fire on VoiceChatPartecipantsInvited
+	//
+	// Handler: func(*Message)
+	OnVoiceChatPartecipantsInvited = "\avoice_chat_partecipants_invited"
 )
 
 // ChatAction is a client-side status indicating bot activity.

--- a/voicechat.go
+++ b/voicechat.go
@@ -1,0 +1,17 @@
+package telebot
+
+// VoiceChatStarted represents a service message about a voice chat
+// started in the chat.
+type VoiceChatStarted struct{}
+
+// VoiceChatEnded represents a service message about a voice chat
+// ended in the chat.
+type VoiceChatEnded struct {
+	Duration int `json:"duration"`
+}
+
+// VoiceChatPartecipantsInvited represents a service message about new
+// members invited to a voice chat
+type VoiceChatPartecipantsInvited struct {
+	Users []User `json:"users"`
+}


### PR DESCRIPTION
Hello,

I wanted to play with the VoiceChat service messages, but telebot lacked the support, hence this PR.
The VoiceChat service messages are part of the bot API v5.1.

I'm not sure of:

 - is it OK to add `voicechat.go` or it's better to stuff those declarations in some other file?
 - The Duration field of the VoiceChatEnded should be a time.Duration instead of a int? (it's the number of seconds)

Cheers!