### PR TITLE
Do not ignore ParseMode for media being sent

### DIFF
--- a/media.go
+++ b/media.go
@@ -80,12 +80,13 @@ type Audio struct {
 	Duration int `json:"duration,omitempty"`
 
 	// (Optional)
-	Caption   string `json:"caption,omitempty"`
-	Thumbnail *Photo `json:"thumb,omitempty"`
-	Title     string `json:"title,omitempty"`
-	Performer string `json:"performer,omitempty"`
-	MIME      string `json:"mime_type,omitempty"`
-	FileName  string `json:"file_name,omitempty"`
+	Caption   string    `json:"caption,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
+	Thumbnail *Photo    `json:"thumb,omitempty"`
+	Title     string    `json:"title,omitempty"`
+	Performer string    `json:"performer,omitempty"`
+	MIME      string    `json:"mime_type,omitempty"`
+	FileName  string    `json:"file_name,omitempty"`
 }
 
 // MediaFile returns &Audio.File
@@ -99,10 +100,11 @@ type Document struct {
 	File
 
 	// (Optional)
-	Thumbnail *Photo `json:"thumb,omitempty"`
-	Caption   string `json:"caption,omitempty"`
-	MIME      string `json:"mime_type"`
-	FileName  string `json:"file_name,omitempty"`
+	Thumbnail *Photo    `json:"thumb,omitempty"`
+	Caption   string    `json:"caption,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
+	MIME      string    `json:"mime_type"`
+	FileName  string    `json:"file_name,omitempty"`
 }
 
 // MediaFile returns &Document.File
@@ -120,11 +122,12 @@ type Video struct {
 	Duration int `json:"duration,omitempty"`
 
 	// (Optional)
-	Caption           string `json:"caption,omitempty"`
-	Thumbnail         *Photo `json:"thumb,omitempty"`
-	SupportsStreaming bool   `json:"supports_streaming,omitempty"`
-	MIME              string `json:"mime_type,omitempty"`
-	FileName          string `json:"file_name,omitempty"`
+	Caption           string    `json:"caption,omitempty"`
+	ParseMode         ParseMode `json:"parse_mode,omitempty"`
+	Thumbnail         *Photo    `json:"thumb,omitempty"`
+	SupportsStreaming bool      `json:"supports_streaming,omitempty"`
+	MIME              string    `json:"mime_type,omitempty"`
+	FileName          string    `json:"file_name,omitempty"`
 }
 
 // MediaFile returns &Video.File
@@ -142,10 +145,11 @@ type Animation struct {
 	Duration int `json:"duration,omitempty"`
 
 	// (Optional)
-	Caption   string `json:"caption,omitempty"`
-	Thumbnail *Photo `json:"thumb,omitempty"`
-	MIME      string `json:"mime_type,omitempty"`
-	FileName  string `json:"file_name,omitempty"`
+	Caption   string    `json:"caption,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
+	Thumbnail *Photo    `json:"thumb,omitempty"`
+	MIME      string    `json:"mime_type,omitempty"`
+	FileName  string    `json:"file_name,omitempty"`
 }
 
 // MediaFile returns &Animation.File

--- a/sendable.go
+++ b/sendable.go
@@ -26,8 +26,9 @@ type Sendable interface {
 // Send delivers media through bot b to recipient.
 func (p *Photo) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	params := map[string]string{
-		"chat_id": to.Recipient(),
-		"caption": p.Caption,
+		"chat_id":    to.Recipient(),
+		"caption":    p.Caption,
+		"parse_mode": p.ParseMode,
 	}
 	b.embedSendOptions(params, opt)
 
@@ -46,11 +47,12 @@ func (p *Photo) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 // Send delivers media through bot b to recipient.
 func (a *Audio) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	params := map[string]string{
-		"chat_id":   to.Recipient(),
-		"caption":   a.Caption,
-		"performer": a.Performer,
-		"title":     a.Title,
-		"file_name": a.FileName,
+		"chat_id":    to.Recipient(),
+		"caption":    a.Caption,
+		"parse_mode": a.ParseMode,
+		"performer":  a.Performer,
+		"title":      a.Title,
+		"file_name":  a.FileName,
 	}
 	b.embedSendOptions(params, opt)
 
@@ -80,9 +82,10 @@ func (a *Audio) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 // Send delivers media through bot b to recipient.
 func (d *Document) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	params := map[string]string{
-		"chat_id":   to.Recipient(),
-		"caption":   d.Caption,
-		"file_name": d.FileName,
+		"chat_id":    to.Recipient(),
+		"caption":    d.Caption,
+		"parse_mode": d.ParseMode,
+		"file_name":  d.FileName,
 	}
 	b.embedSendOptions(params, opt)
 
@@ -123,9 +126,10 @@ func (s *Sticker) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error)
 // Send delivers media through bot b to recipient.
 func (v *Video) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	params := map[string]string{
-		"chat_id":   to.Recipient(),
-		"caption":   v.Caption,
-		"file_name": v.FileName,
+		"chat_id":    to.Recipient(),
+		"caption":    v.Caption,
+		"parse_mode": v.ParseMode,
+		"file_name":  v.FileName,
 	}
 	b.embedSendOptions(params, opt)
 
@@ -167,9 +171,10 @@ func (v *Video) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 // @see https://core.telegram.org/bots/api#sendanimation
 func (a *Animation) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	params := map[string]string{
-		"chat_id":   to.Recipient(),
-		"caption":   a.Caption,
-		"file_name": a.FileName,
+		"chat_id":    to.Recipient(),
+		"caption":    a.Caption,
+		"parse_mode": v.ParseMode,
+		"file_name":  a.FileName,
 	}
 	b.embedSendOptions(params, opt)
 


### PR DESCRIPTION
This ensures that all media being sent have a "ParseMode" flag and that flag is actually included in the API calls being made to Telegram.

Currently Telebot allows setting ParseMode for all media, but then the value was ignored when sending to request to the Telegram APIs.