### PR TITLE
implement my_chat_member and chat_member

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -6,6 +6,61 @@ import (
 	"time"
 )
 
+// ChatInviteLink object represents an invite for a chat.
+type ChatInviteLink struct {
+	// The invite link.
+	InviteLink string `json:"invite_link"`
+
+	// The creator of the link.
+	Creator *User `json:"creator"`
+
+	// If the link is primary.
+	IsPrimary bool `json:"is_primary"`
+
+	// If the link is revoked.
+	IsRevoked bool `json:"is_revoked"`
+
+	// (Optional) Point in time when the link will expire, use
+	// ChatInviteLink.ExpireTime() to get time.Time
+	Unixtime int64 `json:"expire_date,omitempty"`
+
+	// (Optional) Maximum number of users that can be members of
+	// the chat simultaneously.
+	MemberLimit int `json:"member_limit,omitempty"`
+}
+
+// ExpireTime returns the moment of the link expiration in local time.
+func (c *ChatInviteLink) ExpireTime() time.Time {
+	return time.Unix(c.Unixtime, 0)
+}
+
+// ChatMemberUpdated object represents changes in the status of a chat member.
+type ChatMemberUpdated struct {
+	// Chat where the user belongs to.
+	Chat Chat `json:"chat"`
+
+	// From which user the action was triggered.
+	From User `json:"user"`
+
+	// Unixtime, use ChatMemberUpdated.Time() to get time.Time
+	Unixtime int64 `json:"date"`
+
+	// Previous information about the chat member.
+	OldChatMember *ChatMember `json:"old_chat_member"`
+
+	// New information about the chat member.
+	NewChatMember *ChatMember `json:"new_chat_member"`
+
+	// (Optional) ChatInviteLink which was used by the user to
+	// join the chat; for joining by invite link events only.
+	ChatInviteLink *ChatInviteLink `json:"chat_invite_link"`
+}
+
+// Time returns the moment of the change in local time.
+func (c *ChatMemberUpdated) Time() time.Time {
+	return time.Unix(c.Unixtime, 0)
+}
+
 // Rights is a list of privileges available to chat members.
 type Rights struct {
 	CanBeEdited         bool `json:"can_be_edited"`

--- a/bot.go
+++ b/bot.go
@@ -129,6 +129,8 @@ type Update struct {
 	PreCheckoutQuery   *PreCheckoutQuery   `json:"pre_checkout_query,omitempty"`
 	Poll               *Poll               `json:"poll,omitempty"`
 	PollAnswer         *PollAnswer         `json:"poll_answer,omitempty"`
+	MyChatMember       *ChatMemberUpdated  `json:"my_chat_member,omitempty"`
+	ChatMember         *ChatMemberUpdated  `json:"chat_member,omitempty"`
 }
 
 // Command represents a bot command.
@@ -486,6 +488,32 @@ func (b *Bot) ProcessUpdate(upd Update) {
 			}
 
 			b.runHandler(func() { handler(upd.PollAnswer) })
+		}
+
+		return
+	}
+
+	if upd.MyChatMember != nil {
+		if handler, ok := b.handlers[OnMyChatMember]; ok {
+			handler, ok := handler.(func(*ChatMemberUpdated))
+			if !ok {
+				panic("telebot: my chat member handler is bad")
+			}
+
+			b.runHandler(func() { handler(upd.MyChatMember) })
+		}
+
+		return
+	}
+
+	if upd.ChatMember != nil {
+		if handler, ok := b.handlers[OnChatMember]; ok {
+			handler, ok := handler.(func(*ChatMemberUpdated))
+			if !ok {
+				panic("telebot: my chat member handler is bad")
+			}
+
+			b.runHandler(func() { handler(upd.MyChatMember) })
 		}
 
 		return

--- a/telebot.go
+++ b/telebot.go
@@ -120,6 +120,16 @@ const (
 	// Handler: func(*PollAnswer)
 	OnPollAnswer = "\apoll_answer"
 
+	// Will fire on MyChatMember
+	//
+	// Handler: func(*ChatMemberUpdated)
+	OnMyChatMember = "\amy_chat_member"
+
+	// Will fire on ChatMember
+	//
+	// Handler: func(*ChatMemberUpdated)
+	OnChatMember = "\achat_member"
+
 	// Will fire on VoiceChatStarted
 	//
 	// Handler: func(*Message)


### PR DESCRIPTION
This adds the support for the new `my_chat_member` and `chat_member` update types present in bot API v5.1.  `my_chat_member` in particular is handy when you want to know if a bot was added (as an admin) to a channel.

Honestly, I have tested only the `my_chat_member` and not the `chat_member`, but I've added that too since it uses the same struct.