### PR TITLE
Add Caption parameter to Voice structure

### DIFF
--- a/media.go
+++ b/media.go
@@ -161,7 +161,8 @@ type Voice struct {
 	Duration int `json:"duration"`
 
 	// (Optional)
-	MIME string `json:"mime_type,omitempty"`
+	Caption string `json:"caption,omitempty"`
+	MIME    string `json:"mime_type,omitempty"`
 }
 
 // VideoNote represents a video message (available in Telegram apps

--- a/sendable.go
+++ b/sendable.go
@@ -213,6 +213,7 @@ func (a *Animation) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, erro
 func (v *Voice) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	params := map[string]string{
 		"chat_id": to.Recipient(),
+		"caption": v.Caption,
 	}
 	b.embedSendOptions(params, opt)
 


### PR DESCRIPTION
As per #387 adding a Caption to Voice, to reflect the current [Bot API state](https://core.telegram.org/bots/api#sendvoice)