### PR TITLE
use only replay message id instead of whole message in SendOptions

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -711,7 +711,7 @@ func (b *Bot) Reply(to *Message, what interface{}, options ...interface{}) (*Mes
 		sendOpts = &SendOptions{}
 	}
 
-	sendOpts.ReplyTo = to
+	sendOpts.ReplyToID = to.ID
 	return b.Send(to.Chat, what, sendOpts)
 }
 

--- a/options.go
+++ b/options.go
@@ -36,8 +36,8 @@ const (
 // the way through bot logic, so you might want to consider storing
 // and re-using it somewhere or be using Option flags instead.
 type SendOptions struct {
-	// If the message is a reply, original message.
-	ReplyTo *Message
+	// If the message is a reply, original message id.
+	ReplyToID int
 
 	// See ReplyMarkup struct definition.
 	ReplyMarkup *ReplyMarkup
@@ -101,7 +101,7 @@ type ReplyMarkup struct {
 	//
 	// Targets:
 	// 1) Users that are @mentioned in the text of the Message object;
-	// 2) If the bot's message is a reply (has SendOptions.ReplyTo),
+	// 2) If the bot's message is a reply (has SendOptions.ReplyToID),
 	//       sender of the original message.
 	Selective bool `json:"selective,omitempty"`
 }

--- a/util.go
+++ b/util.go
@@ -1,12 +1,13 @@
 package telebot
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"strconv"
-	"bytes"
+
 	"github.com/pkg/errors"
 )
 
@@ -179,8 +180,8 @@ func (b *Bot) embedSendOptions(params map[string]string, opt *SendOptions) {
 		return
 	}
 
-	if opt.ReplyTo != nil && opt.ReplyTo.ID != 0 {
-		params["reply_to_message_id"] = strconv.Itoa(opt.ReplyTo.ID)
+	if opt.ReplyToID != 0 {
+		params["reply_to_message_id"] = strconv.Itoa(opt.ReplyToID)
 	}
 
 	if opt.DisableWebPagePreview {


### PR DESCRIPTION
it is not necessary to store whole `ReplyTo` message in `SendOptions`