### PR TITLE
Add Game to Message for callback query indication

### DIFF
--- a/message.go
+++ b/message.go
@@ -91,7 +91,10 @@ type Message struct {
 
 	// For a photo, all available sizes (thumbnails).
 	Photo *Photo `json:"photo"`
-
+	
+	// For a game, information about it.
+	Game *Game `json:"game"`
+	
 	// For a sticker, information about it.
 	Sticker *Sticker `json:"sticker"`
 


### PR DESCRIPTION
The raw response message from `sendGame` includes a callback query that indicates the requested game.

This game callback indicator is not accessible from the callback handler function itself.
So I thought adding the `Game` to `Message` should solve this. 
The game identifier gets extracted in `Game.Send()` 