### PR TITLE
Some documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ func main() {
 
 	var (
 		// Universal markup builders.
-		menu     = &ReplyMarkup{ResizeReplyKeyboard: true}
-		selector = &ReplyMarkup{}
+		menu     = &tb.ReplyMarkup{ResizeReplyKeyboard: true}
+		selector = &tb.ReplyMarkup{}
 
 		// Reply buttons.
 		btnHelp     = menu.Text("ℹ Help")
@@ -392,7 +392,7 @@ func main() {
 
 You can use markup constructor for every type of possible buttons:
 ```go
-r := &ReplyMarkup{}
+r := &tb.ReplyMarkup{}
 
 // Reply buttons:
 r.Text("Hello!")

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ type Editable interface {
 	// MessageSig is a "message signature".
 	//
 	// For inline messages, return chatID = 0.
-	MessageSig() (messageID int, chatID int64)
+	MessageSig() (messageID string, chatID int64)
 }
 ```
 
@@ -294,11 +294,11 @@ type, provided by telebot:
 // a larger struct, which is often the case (you might
 // want to store some metadata alongside, or might not.)
 type StoredMessage struct {
-	MessageID int   `sql:"message_id" json:"message_id"`
-	ChatID    int64 `sql:"chat_id" json:"chat_id"`
+	MessageID string `sql:"message_id" json:"message_id"`
+	ChatID    int64  `sql:"chat_id" json:"chat_id"`
 }
 
-func (x StoredMessage) MessageSig() (int, int64) {
+func (x StoredMessage) MessageSig() (string, int64) {
 	return x.MessageID, x.ChatID
 }
 ```

--- a/bot.go
+++ b/bot.go
@@ -572,7 +572,7 @@ func (b *Bot) handleMedia(m *Message) bool {
 // some Sendable (or string!) and optional send options.
 //
 // Note: since most arguments are of type interface{}, but have pointer
-// 		method receivers, make sure to pass them by-pointer, NOT by-value.
+// method receivers, make sure to pass them by-pointer, NOT by-value.
 //
 // What is a send option exactly? It can be one of the following types:
 //


### PR DESCRIPTION
* fix comment indentation otherwise go doc browser such as godocs & co would render the "method receivers..." line as a preformatted block.
* sync the example of the Editable interface in the readme to match the actual definition
* for consistency, use `tb.` in every example