### PR TITLE
Webhook poller panics on shutdown because channel is closed before (by Bot)

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -147,8 +147,10 @@ func (h *Webhook) Poll(b *Bot, dest chan Update, stop chan struct{}) {
 }
 
 func (h *Webhook) waitForStop(stop chan struct{}) {
-	<-stop
-	close(stop)
+	_, ok := <-stop
+	if ok {
+		close(stop)
+	}
 }
 
 // The handler simply reads the update from the body of the requests


### PR DESCRIPTION
I set up Bot with webhook poller and after I call bot.Stop() my app panics because webhook tries to close `stop` channel, which is already closed by Bot instance. don't know if it's reasonable to even close this channel inside `waitForStop` channel..