### PR TITLE
Fix CreateInviteLink;EditInviteLink;RevokeInviteLink functions. Add t…

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -6,11 +6,6 @@ import (
 	"time"
 )
 
-// ChatInviteLinkResult object represents an invite for a chat
-type ChatInviteLinkResult struct {
-	Result ChatInviteLink `json:"result"`
-}
-
 // ChatInviteLink object represents an invite for a chat.
 type ChatInviteLink struct {
 	// The invite link.

--- a/admin.go
+++ b/admin.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+// ChatInviteLinkResult object represents an invite for a chat
+type ChatInviteLinkResult struct {
+	Result ChatInviteLink `json:"result"`
+}
+
 // ChatInviteLink object represents an invite for a chat.
 type ChatInviteLink struct {
 	// The invite link.

--- a/bot.go
+++ b/bot.go
@@ -1703,12 +1703,12 @@ func (b *Bot) CreateInviteLink(chat *Chat, link *ChatInviteLink) (*ChatInviteLin
 		return nil, err
 	}
 
-	var resp ChatInviteLink
+	var resp ChatInviteLinkResult
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, wrapError(err)
 	}
 
-	return &resp, nil
+	return &resp.Result, nil
 }
 
 // EditInviteLink edits a non-primary invite link created by the bot.
@@ -1727,19 +1727,19 @@ func (b *Bot) EditInviteLink(chat *Chat, link *ChatInviteLink) (*ChatInviteLink,
 		return nil, err
 	}
 
-	var resp ChatInviteLink
+	var resp ChatInviteLinkResult
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, wrapError(err)
 	}
 
-	return &resp, nil
+	return &resp.Result, nil
 }
 
 // RevokeInviteLink revokes an invite link created by the bot.
 func (b *Bot) RevokeInviteLink(chat *Chat, link string) (*ChatInviteLink, error) {
 	params := map[string]string{
 		"chat_id": chat.Recipient(),
-		"link":    link,
+		"invite_link":    link,
 	}
 
 	data, err := b.Raw("revokeChatInviteLink", params)
@@ -1747,10 +1747,10 @@ func (b *Bot) RevokeInviteLink(chat *Chat, link string) (*ChatInviteLink, error)
 		return nil, err
 	}
 
-	var resp ChatInviteLink
+	var resp ChatInviteLinkResult
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, wrapError(err)
 	}
 
-	return &resp, nil
+	return &resp.Result, nil
 }

--- a/bot.go
+++ b/bot.go
@@ -1703,7 +1703,9 @@ func (b *Bot) CreateInviteLink(chat *Chat, link *ChatInviteLink) (*ChatInviteLin
 		return nil, err
 	}
 
-	var resp ChatInviteLinkResult
+	var resp struct {
+		Result ChatInviteLink `json:"result"`
+	}
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, wrapError(err)
 	}
@@ -1727,7 +1729,9 @@ func (b *Bot) EditInviteLink(chat *Chat, link *ChatInviteLink) (*ChatInviteLink,
 		return nil, err
 	}
 
-	var resp ChatInviteLinkResult
+	var resp struct {
+		Result ChatInviteLink `json:"result"`
+	}
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, wrapError(err)
 	}
@@ -1747,7 +1751,9 @@ func (b *Bot) RevokeInviteLink(chat *Chat, link string) (*ChatInviteLink, error)
 		return nil, err
 	}
 
-	var resp ChatInviteLinkResult
+	var resp struct {
+		Result ChatInviteLink `json:"result"`
+	}
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, wrapError(err)
 	}

--- a/bot_test.go
+++ b/bot_test.go
@@ -480,4 +480,30 @@ func TestBot(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, orig, cmds)
 	})
+
+	t.Run("CreateInviteLink", func(t *testing.T) {
+		inviteLink, err := b.CreateInviteLink(&Chat{ID: chatID}, nil)
+		assert.Nil(t, err)
+		assert.True(t, len(inviteLink.InviteLink) > 0)
+	})
+
+	t.Run("EditInviteLink", func(t *testing.T) {
+		inviteLink, err := b.CreateInviteLink(&Chat{ID: chatID}, nil)
+		assert.Nil(t, err)
+		assert.True(t, len(inviteLink.InviteLink) > 0)
+
+		response, err := b.EditInviteLink(&Chat{ID: chatID}, &ChatInviteLink{InviteLink: inviteLink.InviteLink})
+		assert.Nil(t, err)
+		assert.True(t, len(response.InviteLink) > 0)
+	})
+
+	t.Run("RevokeInviteLink", func(t *testing.T) {
+		inviteLink, err := b.CreateInviteLink(&Chat{ID: chatID}, nil)
+		assert.Nil(t, err)
+		assert.True(t, len(inviteLink.InviteLink) > 0)
+
+		response, err := b.RevokeInviteLink(&Chat{ID: chatID}, inviteLink.InviteLink)
+		assert.Nil(t, err)
+		assert.True(t, len(response.InviteLink) > 0)
+	})
 }


### PR DESCRIPTION
Fix CreateInviteLink & EditInviteLink & RevokeInviteLink responses. Telegram returns 
```json
{"ok":true,"result":{"invite_link":"","creator":{"id":0,"is_bot":true,"first_name":"","username":""},"is_primary":false,"is_revoked":false}}
```

Fix RevokeInviteLink param: link -> invite_link name