### PR TITLE
Use package errors from the standard library instead of github.com/pkg/errors

### DIFF
--- a/api.go
+++ b/api.go
@@ -3,6 +3,7 @@ package telebot
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -12,8 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Raw lets you call any method of Bot API manually.
@@ -73,7 +72,7 @@ func (b *Bot) sendFiles(method string, files map[string]File, params map[string]
 		case f.FileReader != nil:
 			rawFiles[name] = f.FileReader
 		default:
-			return nil, errors.Errorf("telebot: File for field %s doesn't exist", name)
+			return nil, fmt.Errorf("telebot: File for field %s doesn't exist", name)
 		}
 	}
 
@@ -140,7 +139,7 @@ func addFileToWriter(writer *multipart.Writer, filename, field string, file inte
 		defer f.Close()
 		reader = f
 	} else {
-		return errors.Errorf("telebot: File for field %v should be an io.ReadCloser or string", field)
+		return fmt.Errorf("telebot: File for field %v should be an io.ReadCloser or string", field)
 	}
 
 	part, err := writer.CreateFormFile(field, filename)

--- a/bot.go
+++ b/bot.go
@@ -10,8 +10,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // NewBot does try to build a Bot with token `token`, which
@@ -682,7 +680,7 @@ func (b *Bot) SendAlbum(to Recipient, a Album, options ...interface{}) ([]Messag
 			repr = "attach://" + strconv.Itoa(i)
 			files[strconv.Itoa(i)] = *file
 		default:
-			return nil, errors.Errorf("telebot: album entry #%d does not exist", i)
+			return nil, fmt.Errorf("telebot: album entry #%d does not exist", i)
 		}
 
 		switch y := x.(type) {
@@ -749,7 +747,7 @@ func (b *Bot) SendAlbum(to Recipient, a Album, options ...interface{}) ([]Messag
 				ParseMode: sendOpts.ParseMode,
 			})
 		default:
-			return nil, errors.Errorf("telebot: album entry #%d is not valid", i)
+			return nil, fmt.Errorf("telebot: album entry #%d is not valid", i)
 		}
 
 		media[i] = string(data)
@@ -1030,7 +1028,7 @@ func (b *Bot) EditMedia(msg Editable, media InputMedia, options ...interface{}) 
 		repr = "attach://" + s
 		files[s] = *file
 	default:
-		return nil, errors.Errorf("telebot: can't edit media, it does not exist")
+		return nil, fmt.Errorf("telebot: can't edit media, it does not exist")
 	}
 
 	type FileJSON struct {
@@ -1090,7 +1088,7 @@ func (b *Bot) EditMedia(msg Editable, media InputMedia, options ...interface{}) 
 		result.Performer = m.Performer
 		thumb = m.Thumbnail
 	default:
-		return nil, errors.Errorf("telebot: media entry is not valid")
+		return nil, fmt.Errorf("telebot: media entry is not valid")
 	}
 
 	msgID, chatID := msg.MessageSig()
@@ -1334,7 +1332,7 @@ func (b *Bot) GetFile(file *File) (io.ReadCloser, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
-		return nil, errors.Errorf("telebot: expected status 200 but got %s", resp.Status)
+		return nil, fmt.Errorf("telebot: expected status 200 but got %s", resp.Status)
 	}
 
 	return resp.Body, nil

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module gopkg.in/tucnak/telebot.v2
 
 go 1.13
 
-require (
-	github.com/pkg/errors v0.8.1
-	github.com/stretchr/testify v1.5.1
-)
+require github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/telebot.go
+++ b/telebot.go
@@ -28,7 +28,7 @@
 //
 package telebot
 
-import "github.com/pkg/errors"
+import "errors"
 
 var (
 	ErrBadRecipient    = errors.New("telebot: recipient is nil")

--- a/util.go
+++ b/util.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"log"
 	"net/http"
 	"strconv"
@@ -23,7 +22,7 @@ func (b *Bot) deferDebug() {
 		if err, ok := r.(error); ok {
 			b.debug(err)
 		} else if str, ok := r.(string); ok {
-			b.debug(errors.Errorf("%s", str))
+			b.debug(fmt.Errorf("%s", str))
 		}
 	}
 }
@@ -42,7 +41,7 @@ func (b *Bot) runHandler(handler func()) {
 
 // wrapError returns new wrapped telebot-related error.
 func wrapError(err error) error {
-	return errors.Wrap(err, "telebot")
+	return fmt.Errorf("telebot: %w", err)
 }
 
 // extractOk checks given result for error. If result is ok returns nil.


### PR DESCRIPTION
This PR replaces usage of no longer maintained [github.com/pkg/errors](https://github.com/pkg/errors) with package [errors](https://godocs.io/errors) from the standard library.