### PR TITLE
Wait for the active poller to exit when Stop() is called

### DIFF
--- a/api.go
+++ b/api.go
@@ -200,7 +200,6 @@ func (b *Bot) getMe() (*User, error) {
 		return nil, wrapError(err)
 	}
 	return resp.Result, nil
-
 }
 
 func (b *Bot) getUpdates(offset, limit int, timeout time.Duration, allowed []string) ([]Update, error) {


### PR DESCRIPTION
This PR fixes potential goroutine leaks inside `Start()`. Now, when `Stop()` is called, it blocks until `Start()` and its poller goroutines exit.