### PR TITLE
Add album caption parameter to SendAlbum

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -285,7 +285,7 @@ func (b *Bot) Send(to Recipient, what interface{}, opts ...interface{}) (*Messag
 
 // SendAlbum sends multiple instances of media as a single message.
 // From all existing options, it only supports tele.Silent.
-func (b *Bot) SendAlbum(to Recipient, a Album, opts ...interface{}) ([]Message, error) {
+func (b *Bot) SendAlbum(to Recipient, a Album, caption string, opts ...interface{}) ([]Message, error) {
 	if to == nil {
 		return nil, ErrBadRecipient
 	}
@@ -315,7 +315,9 @@ func (b *Bot) SendAlbum(to Recipient, a Album, opts ...interface{}) ([]Message, 
 
 		im := x.InputMedia()
 		im.Media = repr
-
+		if i == 0 && len(caption) > 0 {
+			im.Caption = caption
+		}
 		if len(sendOpts.Entities) > 0 {
 			im.Entities = sendOpts.Entities
 		} else {

--- a/bot_test.go
+++ b/bot_test.go
@@ -405,16 +405,16 @@ func TestBot(t *testing.T) {
 	})
 
 	t.Run("SendAlbum()", func(t *testing.T) {
-		_, err = b.SendAlbum(nil, nil)
+		_, err = b.SendAlbum(nil, nil, "")
 		assert.Equal(t, ErrBadRecipient, err)
 
-		_, err = b.SendAlbum(to, nil)
+		_, err = b.SendAlbum(to, nil, "")
 		assert.Error(t, err)
 
 		photo2 := *photo
 		photo2.Caption = ""
 
-		msgs, err := b.SendAlbum(to, Album{photo, &photo2}, ModeHTML)
+		msgs, err := b.SendAlbum(to, Album{photo, &photo2}, "Caption", ModeHTML)
 		require.NoError(t, err)
 		assert.Len(t, msgs, 2)
 		assert.NotEmpty(t, msgs[0].AlbumID)

--- a/context.go
+++ b/context.go
@@ -354,7 +354,7 @@ func (c *nativeContext) Send(what interface{}, opts ...interface{}) error {
 }
 
 func (c *nativeContext) SendAlbum(a Album, opts ...interface{}) error {
-	_, err := c.b.SendAlbum(c.Recipient(), a, opts...)
+	_, err := c.b.SendAlbum(c.Recipient(), a, "", opts...)
 	return err
 }
 


### PR DESCRIPTION
Even though we can set caption in individual inputtable items, in some applications(such as crossposting bots) you parse and construct  attachments separately from text. After you create a slice of Inputtables, real media items are wrapped in interface and you can't change their caption(because InputMedia() returns value, not a reference). So i added caption parameter to sendAlbum which is assigned to Caption field of first media before sending if caption is not empty. If we don't want to change function signature, we can also add GetCaption/SetCaption to Inputtable interface, so let's discuss