### PR TITLE
.golangci: init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ _testmain.go
 *.prof
 
 .idea
+.vscode
+bin
 .DS_Store
 coverage.txt
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,58 @@
+run:
+  modules-download-mode: readonly
+  issues-exit-code: 0
+  timeout: 5m
+
+linters:
+  enable-all: true
+  disable:
+    # TODO: enable one by one
+    - goconst
+    - nilerr
+    - maintidx
+    - whitespace
+    - prealloc
+    - godox
+    - gocyclo
+    - ifshort
+    - wastedassign
+    - gofumpt
+    - lll
+    - nestif
+    - errchkjson
+    - exportloopref
+    - errorlint
+    - gosimple
+    - tenv
+    - ineffassign
+    - gocritic
+    - gocognit
+    - ireturn
+    - forbidigo
+    - containedctx
+    - tagliatelle
+    - cyclop
+    - errcheck
+    - exhaustivestruct
+    - forcetypeassert
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - goerr113
+    - godot
+    - gomnd
+    - gosec
+    - revive
+    - varnamelen
+    - wrapcheck
+    - noctx
+    - staticcheck
+    - stylecheck
+    - paralleltest
+    - golint      
+    - interfacer 
+    - maligned    
+    - nlreturn    
+    - scopelint   
+    - testpackage 
+    - wsl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+linter:
+	./bin/golangci-lint run ./...
+.PHONY: linter
+
+linter.download:
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
+.PHONY: linter.download
+
+test:
+	env CGO_ENABLED=1 go test -race ./...
+.PHONY: test
+
+alltest: linter test
+.PHONY: alltest


### PR DESCRIPTION
I'd recommend to integrate [golangci-lint](https://golangci-lint.run/) and then enable linter one by one.