### PR TITLE
Do not overwrite inline parsemode

### DIFF
--- a/inline_types.go
+++ b/inline_types.go
@@ -46,9 +46,6 @@ func (r *ResultBase) SetReplyMarkup(markup *ReplyMarkup) {
 }
 
 func (r *ResultBase) Process(b *Bot) {
-	if r.ParseMode == ModeDefault {
-		r.ParseMode = b.parseMode
-	}
 	if r.Content != nil {
 		c, ok := r.Content.(*InputTextMessageContent)
 		if ok && c.ParseMode == ModeDefault {


### PR DESCRIPTION
telebot v3 overwrites the default parsemode `ModeDefault ` for inline results if it differs from the bot's parse mode. This is not always desirable: inline article results to not support, for example, Markdown. 

This PR removes the code that overwrites the parse mode and hands the control over to the developer. 