### PR TITLE
Add option NoRecover to make debugging the library easier

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -44,6 +44,7 @@ func NewBot(pref Settings) (*Bot, error) {
 		stop:     make(chan chan struct{}),
 
 		synchronous: pref.Synchronous,
+		noRecover:   pref.NoRecover,
 		verbose:     pref.Verbose,
 		parseMode:   pref.ParseMode,
 		client:      client,
@@ -75,6 +76,7 @@ type Bot struct {
 	group       *Group
 	handlers    map[string]HandlerFunc
 	synchronous bool
+	noRecover   bool
 	verbose     bool
 	parseMode   ParseMode
 	stop        chan chan struct{}
@@ -96,6 +98,10 @@ type Settings struct {
 	// Synchronous prevents handlers from running in parallel.
 	// It makes ProcessUpdate return after the handler is finished.
 	Synchronous bool
+
+	// Do not recover from panicking in handlers.
+	// Use for debugging purposes only.
+	NoRecover bool
 
 	// Verbose forces bot to log all upcoming requests.
 	// Use for debugging purposes only.

--- a/util.go
+++ b/util.go
@@ -29,7 +29,9 @@ func (b *Bot) deferDebug() {
 
 func (b *Bot) runHandler(h HandlerFunc, c Context) {
 	f := func() {
-		defer b.deferDebug()
+		if !b.noRecover {
+			defer b.deferDebug()
+		}
 		if err := h(c); err != nil {
 			b.OnError(err, c)
 		}


### PR DESCRIPTION
When `recover` is used, only the error message is printed. The debugger cannot catch the panic and it's hard to tell what is going wrong.