### PR TITLE
do cancel poll immediately on bot stop

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -79,6 +79,7 @@ type Bot struct {
 	parseMode   ParseMode
 	stop        chan chan struct{}
 	client      *http.Client
+	stopClient  chan struct{}
 }
 
 // Settings represents a utility struct for passing certain
@@ -207,6 +208,12 @@ func (b *Bot) Start() {
 		panic("telebot: can't start without a poller")
 	}
 
+	// do nothing if called twice
+	if b.stopClient != nil {
+		return
+	}
+	b.stopClient = make(chan struct{})
+
 	stop := make(chan struct{})
 	stopConfirm := make(chan struct{})
 
@@ -225,6 +232,7 @@ func (b *Bot) Start() {
 			close(stop)
 			<-stopConfirm
 			close(confirm)
+			b.stopClient = nil
 			return
 		}
 	}
@@ -232,6 +240,7 @@ func (b *Bot) Start() {
 
 // Stop gracefully shuts the poller down.
 func (b *Bot) Stop() {
+	close(b.stopClient)
 	confirm := make(chan struct{})
 	b.stop <- confirm
 	<-confirm

--- a/bot.go
+++ b/bot.go
@@ -240,7 +240,9 @@ func (b *Bot) Start() {
 
 // Stop gracefully shuts the poller down.
 func (b *Bot) Stop() {
-	close(b.stopClient)
+	if b.stopClient != nil {
+		close(b.stopClient)
+	}
 	confirm := make(chan struct{})
 	b.stop <- confirm
 	<-confirm

--- a/util.go
+++ b/util.go
@@ -14,7 +14,9 @@ var defaultOnError = func(err error, c Context) {
 }
 
 func (b *Bot) debug(err error) {
-	log.Println(err)
+	if b.verbose {
+		log.Println(err)
+	}
 }
 
 func (b *Bot) deferDebug() {


### PR DESCRIPTION
This PR proposes following:  

1. Cancel Raw() call immediately without waiting for the request's timeout when bot is about to stop.
This may become important if doing long polling with long timeout.
2. Make Bot.debug to be aware of Bot.verbose value to be more secure with sensible error messages (e.g. polling failures) which contains bot's token in url value.