### PR TITLE
bot: fix DeleteCommands

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -1473,20 +1473,10 @@ func (b *Bot) SetCommands(opts ...interface{}) error {
 }
 
 // DeleteCommands deletes the list of the bot's commands for the given scope and user language.
-func (b *Bot) DeleteCommands(opts ...interface{}) ([]Command, error) {
+func (b *Bot) DeleteCommands(opts ...interface{}) error {
 	params := extractCommandsParams(opts...)
-	data, err := b.Raw("deleteMyCommands", params)
-	if err != nil {
-		return nil, err
-	}
-
-	var resp struct {
-		Result []Command
-	}
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, wrapError(err)
-	}
-	return resp.Result, nil
+	_, err := b.Raw("deleteMyCommands", params)
+	return err
 }
 
 // Logout logs out from the cloud Bot API server before launching the bot locally.

--- a/bot_test.go
+++ b/bot_test.go
@@ -596,6 +596,10 @@ func TestBot(t *testing.T) {
 		cmds, err = b.Commands(CommandScope{Type: CommandScopeChat, ChatID: chatID}, "en")
 		require.NoError(t, err)
 		assert.Equal(t, orig2, cmds)
+
+		require.NoError(t, b.DeleteCommands(CommandScope{Type: CommandScopeChat, ChatID: chatID}, "en"))
+
+		require.NoError(t, b.DeleteCommands())
 	})
 
 	t.Run("CreateInviteLink", func(t *testing.T) {


### PR DESCRIPTION
This [method](https://core.telegram.org/bots/api#deletemycommands) returns a boolean value, not a command list.