### PR TITLE
fix the order in which template Funcs are applied

### DIFF
--- a/layout/layout.go
+++ b/layout/layout.go
@@ -282,7 +282,7 @@ func (lt *Layout) ButtonLocale(locale, k string, args ...interface{}) *tele.Btn 
 		return nil
 	}
 
-	tmpl, err := lt.template(template.New(k), locale).Funcs(lt.funcs).Parse(string(data))
+	tmpl, err := lt.template(template.New(k).Funcs(lt.funcs), locale).Parse(string(data))
 	if err != nil {
 		log.Println("telebot/layout:", err)
 		return nil


### PR DESCRIPTION
Solution to https://github.com/tucnak/telebot/issues/544.

The bug occured because `layout.template` methods result...
https://github.com/tucnak/telebot/blob/c6bead11749b7621c8338ced665de9ef3028c48f/layout/layout.go#L511-L520
was overwritten by method `template.Funcs(lt.funcs)` which applies...
https://github.com/tucnak/telebot/blob/c6bead11749b7621c8338ced665de9ef3028c48f/layout/layout.go#L285-L289
`builtinFuncs`:
https://github.com/tucnak/telebot/blob/c6bead11749b7621c8338ced665de9ef3028c48f/layout/layout.go#L99-L104