### PR TITLE
bot: add support for the test environment

### DIFF
--- a/api.go
+++ b/api.go
@@ -20,7 +20,7 @@ import (
 // It also handles API errors, so you only need to unwrap
 // result field from json data.
 func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
-	url := b.URL + "/bot" + b.Token + "/" + method
+	url := b.url(method)
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
@@ -68,6 +68,16 @@ func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
 	return data, extractOk(data)
 }
 
+func (b *Bot) url(method string) string {
+	url := b.URL + "/bot" + b.Token
+
+	if b.useTestEnv {
+		url += "/test"
+	}
+
+	return url + "/" + method
+}
+
 func (b *Bot) sendFiles(method string, files map[string]File, params map[string]string) ([]byte, error) {
 	rawFiles := make(map[string]interface{})
 	for name, f := range files {
@@ -113,7 +123,7 @@ func (b *Bot) sendFiles(method string, files map[string]File, params map[string]
 		}
 	}()
 
-	url := b.URL + "/bot" + b.Token + "/" + method
+	url := b.url(method)
 
 	resp, err := b.client.Post(url, writer.FormDataContentType(), pipeReader)
 	if err != nil {

--- a/api_test.go
+++ b/api_test.go
@@ -3,6 +3,7 @@ package telebot
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -117,4 +118,36 @@ func TestExtractMessage(t *testing.T) {
 	data = []byte(`{"ok":true,"result":{"foo":"bar"}}`)
 	_, err = extractMessage(data)
 	require.NoError(t, err)
+}
+
+func TestBot_url(t *testing.T) {
+	url := "https://api.telegram.com"
+	token := "my-token"
+	method := "my-method"
+
+	tests := []struct {
+		name        string
+		useTestEnv  bool
+		expectedURL string
+	}{
+		{"when bot is not set to test environment", false, fmt.Sprintf("%s/bot%s/%s", url, token, method)},
+		{"when bot is set to test environment", true, fmt.Sprintf("%s/bot%s/test/%s", url, token, method)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := Settings{
+				URL:        url,
+				Token:      token,
+				Offline:    true,
+				UseTestEnv: tt.useTestEnv,
+			}
+			bot, err := NewBot(settings)
+
+			assert.NoError(t, err)
+
+			url := bot.url(method)
+
+			assert.Equal(t, tt.expectedURL, url)
+		})
+	}
 }

--- a/bot.go
+++ b/bot.go
@@ -48,6 +48,7 @@ func NewBot(pref Settings) (*Bot, error) {
 		synchronous: pref.Synchronous,
 		verbose:     pref.Verbose,
 		parseMode:   pref.ParseMode,
+		useTestEnv:  pref.UseTestEnv,
 		client:      client,
 	}
 
@@ -79,6 +80,7 @@ type Bot struct {
 	synchronous bool
 	verbose     bool
 	parseMode   ParseMode
+	useTestEnv  bool
 	stop        chan chan struct{}
 	client      *http.Client
 	stopClient  chan struct{}
@@ -119,6 +121,10 @@ type Settings struct {
 
 	// Offline allows to create a bot without network for testing purposes.
 	Offline bool
+
+	// UseTestEnv is used to create a bot on Telegram test environment
+	// https://core.telegram.org/bots/webapps#using-bots-in-the-test-environment
+	UseTestEnv bool
 }
 
 var defaultOnError = func(err error, c Context) {

--- a/bot_test.go
+++ b/bot_test.go
@@ -64,6 +64,7 @@ func TestNewBot(t *testing.T) {
 	pref.Poller = &LongPoller{Timeout: time.Second}
 	pref.Updates = 50
 	pref.ParseMode = ModeHTML
+	pref.UseTestEnv = true
 	pref.Offline = true
 
 	b, err = NewBot(pref)
@@ -73,6 +74,7 @@ func TestNewBot(t *testing.T) {
 	assert.Equal(t, pref.Poller, b.Poller)
 	assert.Equal(t, 50, cap(b.Updates))
 	assert.Equal(t, ModeHTML, b.parseMode)
+	assert.Equal(t, pref.UseTestEnv, b.useTestEnv)
 }
 
 func TestBotHandle(t *testing.T) {


### PR DESCRIPTION
This adds support for Telegram test environment, as requested in #556.

https://core.telegram.org/bots/webapps#using-bots-in-the-test-environment