### PR TITLE
errors: add join request related errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -117,6 +117,8 @@ var (
 	ErrWrongTypeOfContent     = NewError(400, "Bad Request: wrong type of the web page content")
 	ErrWrongURL               = NewError(400, "Bad Request: wrong HTTP URL specified")
 	ErrForwardMessage         = NewError(400, "Bad Request: administrators of the chat restricted message forwarding")
+	ErrAlreadyParticipant     = NewError(400, "Bad Request: USER_ALREADY_PARTICIPANT", "User is already a participant")
+	ErrJoinedChannelsLimit    = NewError(400, "Bad Request: CHANNELS_TOO_MUCH", "User reached joined channels limit")
 )
 
 // Forbidden errors

--- a/errors.go
+++ b/errors.go
@@ -118,7 +118,10 @@ var (
 	ErrWrongURL               = NewError(400, "Bad Request: wrong HTTP URL specified")
 	ErrForwardMessage         = NewError(400, "Bad Request: administrators of the chat restricted message forwarding")
 	ErrAlreadyParticipant     = NewError(400, "Bad Request: USER_ALREADY_PARTICIPANT", "User is already a participant")
-	ErrJoinedChannelsLimit    = NewError(400, "Bad Request: CHANNELS_TOO_MUCH", "User reached joined channels limit")
+	ErrChannelsTooMuch        = NewError(400, "Bad Request: CHANNELS_TOO_MUCH")
+	ErrUserChannelsTooMuch    = NewError(400, "Bad Request: USER_CHANNELS_TOO_MUCH")
+	ErrHideRequesterMissing   = NewError(400, "Bad Request: HIDE_REQUESTER_MISSING")
+	ErrUserIDInvalid          = NewError(400, "Bad Request: USER_ID_INVALID")
 )
 
 // Forbidden errors


### PR DESCRIPTION
I've been creating a bot to accept join requests for high request rate channels of mine.

These were the errors that I wished to handle but I didn't find them at `errors.go` so I added them. 