### PR TITLE
Add support for media spoiler

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -392,8 +392,9 @@ func TestBot(t *testing.T) {
 	assert.Equal(t, ErrBadRecipient, err)
 
 	photo := &Photo{
-		File:    FromURL("https://telegra.ph/file/65c5237b040ebf80ec278.jpg"),
-		Caption: t.Name(),
+		File:       FromURL("https://telegra.ph/file/65c5237b040ebf80ec278.jpg"),
+		Caption:    t.Name(),
+		HasSpoiler: true,
 	}
 	var msg *Message
 
@@ -413,6 +414,7 @@ func TestBot(t *testing.T) {
 
 		photo2 := *photo
 		photo2.Caption = ""
+		photo2.HasSpoiler = false
 
 		msgs, err := b.SendAlbum(to, Album{photo, &photo2}, ModeHTML)
 		require.NoError(t, err)
@@ -461,9 +463,10 @@ func TestBot(t *testing.T) {
 		require.NoError(t, err)
 
 		animation := &Animation{
-			File:     FromDisk(file.Name()),
-			Caption:  t.Name(),
-			FileName: "animation.gif",
+			File:       FromDisk(file.Name()),
+			Caption:    t.Name(),
+			FileName:   "animation.gif",
+			HasSpoiler: true,
 		}
 
 		msg, err := b.Send(msg.Chat, animation)

--- a/media.go
+++ b/media.go
@@ -29,6 +29,7 @@ type InputMedia struct {
 	Performer            string   `json:"performer,omitempty"`
 	Streaming            bool     `json:"supports_streaming,omitempty"`
 	DisableTypeDetection bool     `json:"disable_content_type_detection,omitempty"`
+	HasSpoiler           bool     `json:"has_spoiler,omitempty"`
 }
 
 // Inputtable is a generic type for all kinds of media you
@@ -48,9 +49,10 @@ type Album []Inputtable
 type Photo struct {
 	File
 
-	Width   int    `json:"width"`
-	Height  int    `json:"height"`
-	Caption string `json:"caption,omitempty"`
+	Width      int    `json:"width"`
+	Height     int    `json:"height"`
+	Caption    string `json:"caption,omitempty"`
+	HasSpoiler bool   `json:"has_spoiler,omitempty"`
 }
 
 type photoSize struct {
@@ -71,8 +73,9 @@ func (p *Photo) MediaFile() *File {
 
 func (p *Photo) InputMedia() InputMedia {
 	return InputMedia{
-		Type:    p.MediaType(),
-		Caption: p.Caption,
+		Type:       p.MediaType(),
+		Caption:    p.Caption,
+		HasSpoiler: p.HasSpoiler,
 	}
 }
 
@@ -177,11 +180,12 @@ type Video struct {
 	Duration int `json:"duration,omitempty"`
 
 	// (Optional)
-	Caption   string `json:"caption,omitempty"`
-	Thumbnail *Photo `json:"thumb,omitempty"`
-	Streaming bool   `json:"supports_streaming,omitempty"`
-	MIME      string `json:"mime_type,omitempty"`
-	FileName  string `json:"file_name,omitempty"`
+	Caption    string `json:"caption,omitempty"`
+	Thumbnail  *Photo `json:"thumb,omitempty"`
+	Streaming  bool   `json:"supports_streaming,omitempty"`
+	MIME       string `json:"mime_type,omitempty"`
+	FileName   string `json:"file_name,omitempty"`
+	HasSpoiler bool   `json:"has_spoiler,omitempty"`
 }
 
 func (v *Video) MediaType() string {
@@ -195,12 +199,13 @@ func (v *Video) MediaFile() *File {
 
 func (v *Video) InputMedia() InputMedia {
 	return InputMedia{
-		Type:      v.MediaType(),
-		Caption:   v.Caption,
-		Width:     v.Width,
-		Height:    v.Height,
-		Duration:  v.Duration,
-		Streaming: v.Streaming,
+		Type:       v.MediaType(),
+		Caption:    v.Caption,
+		Width:      v.Width,
+		Height:     v.Height,
+		Duration:   v.Duration,
+		Streaming:  v.Streaming,
+		HasSpoiler: v.HasSpoiler,
 	}
 }
 
@@ -213,10 +218,11 @@ type Animation struct {
 	Duration int `json:"duration,omitempty"`
 
 	// (Optional)
-	Caption   string `json:"caption,omitempty"`
-	Thumbnail *Photo `json:"thumb,omitempty"`
-	MIME      string `json:"mime_type,omitempty"`
-	FileName  string `json:"file_name,omitempty"`
+	Caption    string `json:"caption,omitempty"`
+	Thumbnail  *Photo `json:"thumb,omitempty"`
+	MIME       string `json:"mime_type,omitempty"`
+	FileName   string `json:"file_name,omitempty"`
+	HasSpoiler bool   `json:"has_spoiler,omitempty"`
 }
 
 func (a *Animation) MediaType() string {
@@ -230,11 +236,12 @@ func (a *Animation) MediaFile() *File {
 
 func (a *Animation) InputMedia() InputMedia {
 	return InputMedia{
-		Type:     a.MediaType(),
-		Caption:  a.Caption,
-		Width:    a.Width,
-		Height:   a.Height,
-		Duration: a.Duration,
+		Type:       a.MediaType(),
+		Caption:    a.Caption,
+		Width:      a.Width,
+		Height:     a.Height,
+		Duration:   a.Duration,
+		HasSpoiler: a.HasSpoiler,
 	}
 }
 

--- a/message.go
+++ b/message.go
@@ -88,6 +88,9 @@ type Message struct {
 	// bot commands, etc. that appear in the caption.
 	CaptionEntities Entities `json:"caption_entities,omitempty"`
 
+	// Message media is covered by a spoiler animation.
+	HasMediaSpoiler bool `json:"has_media_spoiler,omitempty"`
+
 	// For an audio recording, information about it.
 	Audio *Audio `json:"audio"`
 
@@ -365,7 +368,6 @@ func (m *Message) FromChannel() bool {
 // Service messages are automatically sent messages, which
 // typically occur on some global action. For instance, when
 // anyone leaves the chat or chat title changes.
-//
 func (m *Message) IsService() bool {
 	fact := false
 
@@ -386,7 +388,6 @@ func (m *Message) IsService() bool {
 //
 // It's safer than manually slicing Text because Telegram uses
 // UTF-16 indices whereas Go string are []byte.
-//
 func (m *Message) EntityText(e MessageEntity) string {
 	text := m.Text
 	if text == "" {


### PR DESCRIPTION
According to the Bot API 6.4 changes on December 30, 2022:
- Added field `HasSpoiler` to `Photo`, `Video` and `Animation` media structs.
- Added field `HasMediaSpoiler` to `Message` struct.
