### PR TITLE
media: add missed CustomEmoji field to the Sticker

### DIFF
--- a/media.go
+++ b/media.go
@@ -279,15 +279,17 @@ func (v *VideoNote) MediaFile() *File {
 // Sticker object represents a WebP image, so-called sticker.
 type Sticker struct {
 	File
-	Width            int           `json:"width"`
-	Height           int           `json:"height"`
-	Animated         bool          `json:"is_animated"`
-	Video            bool          `json:"is_video"`
-	Thumbnail        *Photo        `json:"thumb"`
-	Emoji            string        `json:"emoji"`
-	SetName          string        `json:"set_name"`
-	MaskPosition     *MaskPosition `json:"mask_position"`
-	PremiumAnimation *File         `json:"premium_animation"`
+	Width            int            `json:"width"`
+	Height           int            `json:"height"`
+	Animated         bool           `json:"is_animated"`
+	Video            bool           `json:"is_video"`
+	Thumbnail        *Photo         `json:"thumb"`
+	Emoji            string         `json:"emoji"`
+	SetName          string         `json:"set_name"`
+	MaskPosition     *MaskPosition  `json:"mask_position"`
+	PremiumAnimation *File          `json:"premium_animation"`
+	Type             StickerSetType `json:"type"`
+	CustomEmoji      string         `json:"custom_emoji_id,omitempty"`
 }
 
 func (s *Sticker) MediaType() string {


### PR DESCRIPTION
### Bot API 6.2
**Custom Emoji Support**

- Added the fields type and custom_emoji_id to the class Sticker.