### PR TITLE
Chore: replaced `io/ioutil` package

### DIFF
--- a/api.go
+++ b/api.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -55,7 +54,7 @@ func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
 	resp.Close = true
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, wrapError(err)
 	}
@@ -128,7 +127,7 @@ func (b *Bot) sendFiles(method string, files map[string]File, params map[string]
 		return nil, ErrInternal
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, wrapError(err)
 	}

--- a/bot_test.go
+++ b/bot_test.go
@@ -3,7 +3,6 @@ package telebot
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -454,7 +453,7 @@ func TestBot(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		file, err := ioutil.TempFile("", "")
+		file, err := os.CreateTemp("", "")
 		require.NoError(t, err)
 
 		_, err = io.Copy(file, resp.Body)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/telebot.v3
 
-go 1.13
+go 1.16
 
 require (
 	github.com/goccy/go-yaml v1.9.5

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -3,8 +3,8 @@ package layout
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"text/template"
@@ -69,7 +69,7 @@ type (
 
 // New parses the given layout file.
 func New(path string, funcs ...template.FuncMap) (*Layout, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -121,10 +121,10 @@ var builtinFuncs = template.FuncMap{
 //		webhook: (or webhook settings)
 //
 // Usage:
+//
 //	lt, err := layout.New("bot.yml")
 //	b, err := tele.NewBot(lt.Settings())
 //	// That's all!
-//
 func (lt *Layout) Settings() tele.Settings {
 	if lt.pref == nil {
 		panic("telebot/layout: settings is empty")
@@ -183,16 +183,20 @@ func (lt *Layout) Commands() (cmds []tele.Command) {
 // used in b.SetCommands later.
 //
 // Example of bot.yml:
+//
 //	commands:
 //	  /start: '{{ text "cmdStart" }}'
 //
 // en.yml:
+//
 //	cmdStart: Start the bot
 //
 // ru.yml:
+//
 //	cmdStart: Запуск бота
 //
 // Usage:
+//
 //	b.SetCommands(lt.CommandsLocale("en"), "en")
 //	b.SetCommands(lt.CommandsLocale("ru"), "ru")
 func (lt *Layout) CommandsLocale(locale string, args ...interface{}) (cmds []tele.Command) {
@@ -226,13 +230,14 @@ func (lt *Layout) CommandsLocale(locale string, args ...interface{}) (cmds []tel
 // The given optional argument will be passed to the template engine.
 //
 // Example of en.yml:
+//
 //	start: Hi, {{.FirstName}}!
 //
 // Usage:
+//
 //	func onStart(c tele.Context) error {
 //		return c.Send(lt.Text(c, "start", c.Sender()))
 //	}
-//
 func (lt *Layout) Text(c tele.Context, k string, args ...interface{}) string {
 	locale, ok := lt.Locale(c)
 	if !ok {
@@ -266,9 +271,9 @@ func (lt *Layout) TextLocale(locale, k string, args ...interface{}) string {
 // Callback returns a callback endpoint used to handle buttons.
 //
 // Example:
+//
 //	// Handling settings button
 //	b.Handle(lt.Callback("settings"), onSettings)
-//
 func (lt *Layout) Callback(k string) tele.CallbackEndpoint {
 	btn, ok := lt.buttons[k]
 	if !ok {
@@ -287,6 +292,7 @@ func (lt *Layout) Callback(k string) tele.CallbackEndpoint {
 //			text: Item #{{.Number}}
 //
 // Usage:
+//
 //	btns := make([]tele.Btn, len(items))
 //	for i, item := range items {
 //		btns[i] = lt.Button(c, "item", struct {
@@ -301,7 +307,6 @@ func (lt *Layout) Callback(k string) tele.CallbackEndpoint {
 //	m := b.NewMarkup()
 //	m.Inline(m.Row(btns...))
 //	// Your generated markup is ready.
-//
 func (lt *Layout) Button(c tele.Context, k string, args ...interface{}) *tele.Btn {
 	locale, ok := lt.Locale(c)
 	if !ok {
@@ -360,13 +365,13 @@ func (lt *Layout) ButtonLocale(locale, k string, args ...interface{}) *tele.Btn 
 //		- [settings]
 //
 // Usage:
+//
 //	func onStart(c tele.Context) error {
 //		return c.Send(
 //			lt.Text(c, "start"),
 //			lt.Markup(c, "menu"),
 //		)
 //	}
-//
 func (lt *Layout) Markup(c tele.Context, k string, args ...interface{}) *tele.ReplyMarkup {
 	locale, ok := lt.Locale(c)
 	if !ok {
@@ -427,6 +432,7 @@ func (lt *Layout) MarkupLocale(locale, k string, args ...interface{}) *tele.Repl
 //			thumb_url: '{{ .PreviewURL }}'
 //
 // Usage:
+//
 //	func onQuery(c tele.Context) error {
 //		results := make(tele.Results, len(articles))
 //		for i, article := range articles {
@@ -437,7 +443,6 @@ func (lt *Layout) MarkupLocale(locale, k string, args ...interface{}) *tele.Repl
 //			CacheTime: 100,
 //		})
 //	}
-//
 func (lt *Layout) Result(c tele.Context, k string, args ...interface{}) tele.Result {
 	locale, ok := lt.Locale(c)
 	if !ok {

--- a/layout/parser.go
+++ b/layout/parser.go
@@ -2,7 +2,6 @@ package layout
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -241,7 +240,7 @@ func (lt *Layout) parseLocales(dir string) error {
 			return nil
 		}
 
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I replaced `io/ioutil` package with `os` and `io` package.

With the two proposals accepted (https://github.com/golang/go/issues/42026 and https://github.com/golang/go/issues/40025), the package io/ioutil will be deprecated and new code is encouraged to use the respective implementations in the packages io and os.

Because the Go version used by GitHub Action's workflow is already 1.16, I also increased the version of gomod to 1.16.