### PR TITLE
bot: add an ability to use custom url builder

### DIFF
--- a/api.go
+++ b/api.go
@@ -20,7 +20,7 @@ import (
 // It also handles API errors, so you only need to unwrap
 // result field from json data.
 func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
-	url := b.URL + "/bot" + b.Token + "/" + method
+	url := b.URLBuilder(b.URL, b.Token, method)
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
@@ -113,7 +113,7 @@ func (b *Bot) sendFiles(method string, files map[string]File, params map[string]
 		}
 	}()
 
-	url := b.URL + "/bot" + b.Token + "/" + method
+	url := b.URLBuilder(b.URL, b.Token, method)
 
 	resp, err := b.client.Post(url, writer.FormDataContentType(), pipeReader)
 	if err != nil {

--- a/bot_test.go
+++ b/bot_test.go
@@ -47,6 +47,12 @@ func TestNewBot(t *testing.T) {
 	_, err = NewBot(pref)
 	assert.Error(t, err)
 
+	pref.URLBuilder = func(URL string, token string, method string) string {
+		return "BAD URL BUILDER"
+	}
+	_, err = NewBot(pref)
+	assert.Error(t, err)
+
 	b, err := NewBot(Settings{Offline: true})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Same reasons as for #558, but a more robust solution as allows to use one of the setting's fields instead of two (URL and test env switcher)