### PR TITLE
chat: add missed is_member field to ChatMember

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -101,6 +101,7 @@ type ChatMember struct {
 	Role      MemberStatus `json:"status"`
 	Title     string       `json:"custom_title"`
 	Anonymous bool         `json:"is_anonymous"`
+	Member    bool         `json:"is_member,omitempty"`
 
 	// Date when restrictions will be lifted for the user, unix time.
 	//


### PR DESCRIPTION
Added is_member field for ChatMember. Previously, it was not possible to check whether a ChatMemberRestricted had joined or left a chat.