### PR TITLE
api: fix race for a stopClient channel

### DIFF
--- a/api.go
+++ b/api.go
@@ -36,7 +36,7 @@ func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
 
 	go func() {
 		select {
-		case <-b.stopClient:
+		case <-b.getChanStopClient():
 			cancel()
 		case <-exit:
 		}

--- a/api.go
+++ b/api.go
@@ -20,7 +20,7 @@ import (
 // It also handles API errors, so you only need to unwrap
 // result field from json data.
 func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
-	url := b.URL + "/bot" + b.Token + "/" + method
+	url := b.url(method)
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
@@ -66,6 +66,16 @@ func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
 
 	// returning data as well
 	return data, extractOk(data)
+}
+
+func (b *Bot) url(method string) string {
+	url := b.URL + "/bot" + b.Token
+
+	if b.useTestEnv {
+		url += "/test"
+	}
+
+	return url + "/" + method
 }
 
 func (b *Bot) sendFiles(method string, files map[string]File, params map[string]string) ([]byte, error) {

--- a/bot.go
+++ b/bot.go
@@ -49,6 +49,7 @@ func NewBot(pref Settings) (*Bot, error) {
 		synchronous: pref.Synchronous,
 		verbose:     pref.Verbose,
 		parseMode:   pref.ParseMode,
+		useTestEnv:  pref.UseTestEnv,
 		client:      client,
 	}
 
@@ -80,6 +81,7 @@ type Bot struct {
 	synchronous bool
 	verbose     bool
 	parseMode   ParseMode
+	useTestEnv  bool
 	stop        chan chan struct{}
 	client      *http.Client
 	stopClient  chan struct{}
@@ -122,6 +124,10 @@ type Settings struct {
 
 	// Offline allows to create a bot without network for testing purposes.
 	Offline bool
+
+	// UseTestEnv is used to create a bot on Telegram test environment
+	// https://core.telegram.org/bots/webapps#using-bots-in-the-test-environment
+	UseTestEnv bool
 }
 
 var defaultOnError = func(err error, c Context) {
@@ -163,18 +169,17 @@ var (
 //
 // Example:
 //
-//		b.Handle("/start", func (c tele.Context) error {
-//			return c.Reply("Hello!")
-// 		})
+//	b.Handle("/start", func (c tele.Context) error {
+//		return c.Reply("Hello!")
+//	})
 //
-//		b.Handle(&inlineButton, func (c tele.Context) error {
-//			return c.Respond(&tele.CallbackResponse{Text: "Hello!"})
-//		})
+//	b.Handle(&inlineButton, func (c tele.Context) error {
+//		return c.Respond(&tele.CallbackResponse{Text: "Hello!"})
+//	})
 //
 // Middleware usage:
 //
-//		b.Handle("/ban", onBan, middleware.Whitelist(ids...))
-//
+//	b.Handle("/ban", onBan, middleware.Whitelist(ids...))
 func (b *Bot) Handle(endpoint interface{}, h HandlerFunc, m ...MiddlewareFunc) {
 	if len(b.group.middleware) > 0 {
 		m = append(b.group.middleware, m...)
@@ -260,16 +265,16 @@ func (b *Bot) NewContext(u Update) Context {
 // some Sendable (or string!) and optional send options.
 //
 // NOTE:
-// 		Since most arguments are of type interface{}, but have pointer
-// 		method receivers, make sure to pass them by-pointer, NOT by-value.
+//
+//	Since most arguments are of type interface{}, but have pointer
+//	method receivers, make sure to pass them by-pointer, NOT by-value.
 //
 // What is a send option exactly? It can be one of the following types:
 //
-//     - *SendOptions (the actual object accepted by Telegram API)
-//     - *ReplyMarkup (a component of SendOptions)
-//     - Option (a shortcut flag for popular options)
-//     - ParseMode (HTML, Markdown, etc)
-//
+//   - *SendOptions (the actual object accepted by Telegram API)
+//   - *ReplyMarkup (a component of SendOptions)
+//   - Option (a shortcut flag for popular options)
+//   - ParseMode (HTML, Markdown, etc)
 func (b *Bot) Send(to Recipient, what interface{}, opts ...interface{}) (*Message, error) {
 	if to == nil {
 		return nil, ErrBadRecipient
@@ -441,14 +446,13 @@ func (b *Bot) Copy(to Recipient, msg Editable, options ...interface{}) (*Message
 //
 // Use cases:
 //
-//     b.Edit(m, m.Text, newMarkup)
-//     b.Edit(m, "new <b>text</b>", tele.ModeHTML)
-//     b.Edit(m, &tele.ReplyMarkup{...})
-//     b.Edit(m, &tele.Photo{File: ...})
-//     b.Edit(m, tele.Location{42.1337, 69.4242})
-//     b.Edit(c, "edit inline message from the callback")
-//     b.Edit(r, "edit message from chosen inline result")
-//
+//	b.Edit(m, m.Text, newMarkup)
+//	b.Edit(m, "new <b>text</b>", tele.ModeHTML)
+//	b.Edit(m, &tele.ReplyMarkup{...})
+//	b.Edit(m, &tele.Photo{File: ...})
+//	b.Edit(m, tele.Location{42.1337, 69.4242})
+//	b.Edit(c, "edit inline message from the callback")
+//	b.Edit(r, "edit message from chosen inline result")
 func (b *Bot) Edit(msg Editable, what interface{}, opts ...interface{}) (*Message, error) {
 	var (
 		method string
@@ -507,7 +511,6 @@ func (b *Bot) Edit(msg Editable, what interface{}, opts ...interface{}) (*Messag
 //
 // If edited message is sent by the bot, returns it,
 // otherwise returns nil and ErrTrueResult.
-//
 func (b *Bot) EditReplyMarkup(msg Editable, markup *ReplyMarkup) (*Message, error) {
 	msgID, chatID := msg.MessageSig()
 	params := make(map[string]string)
@@ -541,7 +544,6 @@ func (b *Bot) EditReplyMarkup(msg Editable, markup *ReplyMarkup) (*Message, erro
 //
 // If edited message is sent by the bot, returns it,
 // otherwise returns nil and ErrTrueResult.
-//
 func (b *Bot) EditCaption(msg Editable, caption string, opts ...interface{}) (*Message, error) {
 	msgID, chatID := msg.MessageSig()
 
@@ -575,9 +577,8 @@ func (b *Bot) EditCaption(msg Editable, caption string, opts ...interface{}) (*M
 //
 // Use cases:
 //
-//     b.EditMedia(m, &tele.Photo{File: tele.FromDisk("chicken.jpg")})
-//     b.EditMedia(m, &tele.Video{File: tele.FromURL("http://video.mp4")})
-//
+//	b.EditMedia(m, &tele.Photo{File: tele.FromDisk("chicken.jpg")})
+//	b.EditMedia(m, &tele.Video{File: tele.FromURL("http://video.mp4")})
 func (b *Bot) EditMedia(msg Editable, media Inputtable, opts ...interface{}) (*Message, error) {
 	var (
 		repr  string
@@ -659,15 +660,14 @@ func (b *Bot) EditMedia(msg Editable, media Inputtable, opts ...interface{}) (*M
 // Delete removes the message, including service messages.
 // This function will panic upon nil Editable.
 //
-//     - A message can only be deleted if it was sent less than 48 hours ago.
-//     - A dice message in a private chat can only be deleted if it was sent more than 24 hours ago.
-//     - Bots can delete outgoing messages in private chats, groups, and supergroups.
-//     - Bots can delete incoming messages in private chats.
-//     - Bots granted can_post_messages permissions can delete outgoing messages in channels.
-//     - If the bot is an administrator of a group, it can delete any message there.
-//     - If the bot has can_delete_messages permission in a supergroup or a
-//       channel, it can delete any message there.
-//
+//   - A message can only be deleted if it was sent less than 48 hours ago.
+//   - A dice message in a private chat can only be deleted if it was sent more than 24 hours ago.
+//   - Bots can delete outgoing messages in private chats, groups, and supergroups.
+//   - Bots can delete incoming messages in private chats.
+//   - Bots granted can_post_messages permissions can delete outgoing messages in channels.
+//   - If the bot is an administrator of a group, it can delete any message there.
+//   - If the bot has can_delete_messages permission in a supergroup or a
+//     channel, it can delete any message there.
 func (b *Bot) Delete(msg Editable) error {
 	msgID, chatID := msg.MessageSig()
 
@@ -689,7 +689,6 @@ func (b *Bot) Delete(msg Editable) error {
 //
 // Currently, Telegram supports only a narrow range of possible
 // actions, these are aligned as constants of this package.
-//
 func (b *Bot) Notify(to Recipient, action ChatAction) error {
 	if to == nil {
 		return ErrBadRecipient
@@ -709,10 +708,9 @@ func (b *Bot) Notify(to Recipient, action ChatAction) error {
 //
 // Example:
 //
-//		b.Ship(query)          // OK
-//		b.Ship(query, opts...) // OK with options
-//		b.Ship(query, "Oops!") // Error message
-//
+//	b.Ship(query)          // OK
+//	b.Ship(query, opts...) // OK with options
+//	b.Ship(query, "Oops!") // Error message
 func (b *Bot) Ship(query *ShippingQuery, what ...interface{}) error {
 	params := map[string]string{
 		"shipping_query_id": query.ID,
@@ -765,9 +763,8 @@ func (b *Bot) Accept(query *PreCheckoutQuery, errorMessage ...string) error {
 //
 // Example:
 //
-//		b.Respond(c)
-//		b.Respond(c, response)
-//
+//	b.Respond(c)
+//	b.Respond(c, response)
 func (b *Bot) Respond(c *Callback, resp ...*CallbackResponse) error {
 	var r *CallbackResponse
 	if resp == nil {
@@ -825,7 +822,6 @@ func (b *Bot) AnswerWebApp(query *Query, r Result) (*WebAppMessage, error) {
 //
 // Usually, Telegram-provided File objects miss FilePath so you might need to
 // perform an additional request to fetch them.
-//
 func (b *Bot) FileByID(fileID string) (File, error) {
 	params := map[string]string{
 		"file_id": fileID,
@@ -905,7 +901,6 @@ func (b *Bot) File(file *File) (io.ReadCloser, error) {
 //
 // If the message is sent by the bot, returns it,
 // otherwise returns nil and ErrTrueResult.
-//
 func (b *Bot) StopLiveLocation(msg Editable, opts ...interface{}) (*Message, error) {
 	msgID, chatID := msg.MessageSig()
 
@@ -930,7 +925,6 @@ func (b *Bot) StopLiveLocation(msg Editable, opts ...interface{}) (*Message, err
 //
 // It supports ReplyMarkup.
 // This function will panic upon nil Editable.
-//
 func (b *Bot) StopPoll(msg Editable, opts ...interface{}) (*Poll, error) {
 	msgID, chatID := msg.MessageSig()
 
@@ -970,7 +964,6 @@ func (b *Bot) Leave(chat *Chat) error {
 //
 // It supports Silent option.
 // This function will panic upon nil Editable.
-//
 func (b *Bot) Pin(msg Editable, opts ...interface{}) error {
 	msgID, chatID := msg.MessageSig()
 
@@ -1015,7 +1008,6 @@ func (b *Bot) UnpinAll(chat *Chat) error {
 //
 // Including current name of the user for one-on-one conversations,
 // current username of a user, group or channel, etc.
-//
 func (b *Bot) ChatByID(id int64) (*Chat, error) {
 	return b.ChatByUsername(strconv.FormatInt(id, 10))
 }
@@ -1113,9 +1105,8 @@ func (b *Bot) MenuButton(chat *User) (*MenuButton, error) {
 //
 // It accepts two kinds of menu button arguments:
 //
-//     - MenuButtonType for simple menu buttons (default, commands)
-//     - MenuButton complete structure for web_app menu button type
-//
+//   - MenuButtonType for simple menu buttons (default, commands)
+//   - MenuButton complete structure for web_app menu button type
 func (b *Bot) SetMenuButton(chat *User, mb interface{}) error {
 	params := map[string]interface{}{
 		"chat_id": chat.Recipient(),

--- a/bot.go
+++ b/bot.go
@@ -199,10 +199,11 @@ func (b *Bot) Start() {
 	}
 
 	// do nothing if called twice
-	if b.stopClient != nil {
+	if b.getChanStopClient() != nil {
 		return
 	}
-	b.stopClient = make(chan struct{})
+
+	b.createNewChanStopClient()
 
 	stop := make(chan struct{})
 	stopConfirm := make(chan struct{})
@@ -222,7 +223,7 @@ func (b *Bot) Start() {
 			close(stop)
 			<-stopConfirm
 			close(confirm)
-			b.stopClient = nil
+			b.destroyChanStopClient()
 			return
 		}
 	}
@@ -230,8 +231,8 @@ func (b *Bot) Start() {
 
 // Stop gracefully shuts the poller down.
 func (b *Bot) Stop() {
-	if b.stopClient != nil {
-		close(b.stopClient)
+	if b.getChanStopClient() != nil {
+		b.closeChanStopClient()
 	}
 	confirm := make(chan struct{})
 	b.stop <- confirm

--- a/bot.go
+++ b/bot.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -82,6 +83,8 @@ type Bot struct {
 	stop        chan chan struct{}
 	client      *http.Client
 	stopClient  chan struct{}
+
+	stopClientMux sync.RWMutex
 }
 
 // Settings represents a utility struct for passing certain

--- a/bot_test.go
+++ b/bot_test.go
@@ -64,6 +64,7 @@ func TestNewBot(t *testing.T) {
 	pref.Poller = &LongPoller{Timeout: time.Second}
 	pref.Updates = 50
 	pref.ParseMode = ModeHTML
+	pref.UseTestEnv = true
 	pref.Offline = true
 
 	b, err = NewBot(pref)
@@ -73,6 +74,7 @@ func TestNewBot(t *testing.T) {
 	assert.Equal(t, pref.Poller, b.Poller)
 	assert.Equal(t, 50, cap(b.Updates))
 	assert.Equal(t, ModeHTML, b.parseMode)
+	assert.Equal(t, pref.UseTestEnv, b.useTestEnv)
 }
 
 func TestBotHandle(t *testing.T) {

--- a/channel.go
+++ b/channel.go
@@ -10,7 +10,7 @@ func (b *Bot) getChanStopClient() chan struct{} {
 func (b *Bot) closeChanStopClient() {
 	b.stopClientMux.Lock()
 	defer b.stopClientMux.Unlock()
-	
+
 	close(b.stopClient)
 }
 

--- a/channel.go
+++ b/channel.go
@@ -1,0 +1,17 @@
+package telebot
+
+func (b *Bot) getChanStopClient() chan struct{} {
+	return b.stopClient
+}
+
+func (b *Bot) createNewChanStopClient() {
+	b.stopClient = make(chan struct{})
+}
+
+func (b *Bot) closeChanStopClient() {
+	close(b.stopClient)
+}
+
+func (b *Bot) destroyChanStopClient() {
+	b.stopClient = nil
+}

--- a/channel.go
+++ b/channel.go
@@ -1,17 +1,29 @@
 package telebot
 
 func (b *Bot) getChanStopClient() chan struct{} {
+	b.stopClientMux.RLock()
+	defer b.stopClientMux.RUnlock()
+
 	return b.stopClient
 }
 
-func (b *Bot) createNewChanStopClient() {
-	b.stopClient = make(chan struct{})
-}
-
 func (b *Bot) closeChanStopClient() {
+	b.stopClientMux.Lock()
+	defer b.stopClientMux.Unlock()
+	
 	close(b.stopClient)
 }
 
+func (b *Bot) createNewChanStopClient() {
+	b.stopClientMux.Lock()
+	defer b.stopClientMux.Unlock()
+
+	b.stopClient = make(chan struct{})
+}
+
 func (b *Bot) destroyChanStopClient() {
+	b.stopClientMux.Lock()
+	defer b.stopClientMux.Unlock()
+
 	b.stopClient = nil
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -38,7 +38,10 @@ func TestRaceStopClientChannel(t *testing.T) {
 
 	// act and assert
 	go api.Start()
-	defer api.Close()
+	defer func() {
+		_, err = api.Close()
+		require.NoError(t, err)
+	}()
 
 	<-syncChan
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -1,0 +1,44 @@
+package telebot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRaceStopClientChannel(t *testing.T) {
+	t.Parallel()
+
+	api, err := NewBot(Settings{Offline: true})
+	require.NoError(t, err)
+
+	syncChan := make(chan struct{})
+
+	go func() {
+		syncChan <- struct{}{}
+
+		_, err = api.Raw("setMyCommands", CommandParams{
+			Commands: []Command{
+				{
+					Text:        "/test",
+					Description: "test",
+				},
+			},
+			LanguageCode: "en",
+		})
+		require.EqualError(t, err, "telegram: Not Found (404)")
+
+		close(syncChan)
+	}()
+
+	<-syncChan
+
+	time.Sleep(time.Second)
+
+	// act and assert
+	go api.Start()
+	defer api.Close()
+
+	<-syncChan
+}


### PR DESCRIPTION
# Problem

Before starting the bot I do a setCommands and its goroutine [`which reads channel variable`] does not have time to complete before the start method [`which writes to channel variable`].

Previous read at 0x00c0015a6628 by goroutine 106:
 [ https://github.com/tucnak/telebot/blob/v3/api.go#L39](https://github.com/tucnak/telebot/blob/v3/api.go#L39)

Write at 0x00c0015a6628 by main goroutine:
 [ https://github.com/tucnak/telebot/blob/v3/bot.go#L205](https://github.com/tucnak/telebot/blob/v3/bot.go#L205)

# Decision

Use mutex for use channel `stopClient`.

Also added changes from https://github.com/caalberts/telebot to work with testnet.