### PR TITLE
api 6.5: implement keyboard buttons request_user and request_chat

### DIFF
--- a/markup.go
+++ b/markup.go
@@ -206,10 +206,12 @@ func (r *ReplyMarkup) WebApp(text string, app *WebApp) Btn {
 type ReplyButton struct {
 	Text string `json:"text"`
 
-	Contact  bool     `json:"request_contact,omitempty"`
-	Location bool     `json:"request_location,omitempty"`
-	Poll     PollType `json:"request_poll,omitempty"`
-	WebApp   *WebApp  `json:"web_app,omitempty"`
+	Contact  bool                       `json:"request_contact,omitempty"`
+	Location bool                       `json:"request_location,omitempty"`
+	Poll     PollType                   `json:"request_poll,omitempty"`
+	User     *KeyboardButtonRequestUser `json:"request_user,omitempty"`
+	Chat     *KeyboardButtonRequestChat `json:"request_chat,omitempty"`
+	WebApp   *WebApp                    `json:"web_app,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler. It allows passing PollType as a

--- a/message.go
+++ b/message.go
@@ -223,6 +223,9 @@ type Message struct {
 	// Message is a service message about a successful payment.
 	Payment *Payment `json:"successful_payment"`
 
+	UserShared *UserShared `json:"user_shared,omitempty"`
+	ChatShared *ChatShared `json:"chat_shared,omitempty"`
+
 	// The domain name of the website on which the user has logged in.
 	ConnectedWebsite string `json:"connected_website,omitempty"`
 

--- a/request_chat.go
+++ b/request_chat.go
@@ -1,0 +1,18 @@
+package telebot
+
+type KeyboardButtonRequestChat struct {
+	ID int32 `json:"request_id"`
+
+	IsChannel       bool    `json:"chat_is_channel,omitempty"`
+	IsForum         bool    `json:"chat_is_forum,omitempty"`
+	HasUsername     bool    `json:"chat_has_username,omitempty"`
+	IsCreated       bool    `json:"chat_is_created,omitempty"`
+	UserAdminRights *Rights `json:"user_administrator_rights,omitempty"`
+	BotAdminRights  *Rights `json:"bot_administrator_rights,omitempty"`
+	BotIsMember     bool    `json:"bot_is_member,omitempty"`
+}
+
+type ChatShared struct {
+	ID     int32 `json:"request_id"`
+	ChatID int64 `json:"chat_id"`
+}

--- a/request_user.go
+++ b/request_user.go
@@ -1,0 +1,13 @@
+package telebot
+
+type KeyboardButtonRequestUser struct {
+	ID int32 `json:"request_id"`
+
+	IsBot     bool `json:"user_is_bot,omitempty"`
+	IsPremium bool `json:"user_is_premium,omitempty"`
+}
+
+type UserShared struct {
+	ID     int32 `json:"request_id"`
+	UserID int64 `json:"user_id"`
+}

--- a/telebot.go
+++ b/telebot.go
@@ -72,6 +72,8 @@ const (
 	OnAddedToGroup      = "\aadded_to_group"
 	OnUserJoined        = "\auser_joined"
 	OnUserLeft          = "\auser_left"
+	OnUserShared        = "\auser_shared"
+	OnChatShared        = "\achat_shared"
 	OnNewGroupTitle     = "\anew_chat_title"
 	OnNewGroupPhoto     = "\anew_chat_photo"
 	OnGroupPhotoDeleted = "\achat_photo_deleted"

--- a/update.go
+++ b/update.go
@@ -124,6 +124,16 @@ func (b *Bot) ProcessUpdate(u Update) {
 			return
 		}
 
+		if m.UserShared != nil {
+			b.handle(OnUserShared, c)
+			return
+		}
+
+		if m.ChatShared != nil {
+			b.handle(OnChatShared, c)
+			return
+		}
+
 		if m.NewGroupTitle != "" {
 			b.handle(OnNewGroupTitle, c)
 			return


### PR DESCRIPTION
The Telegram Bot API now includes `request_chat` and `request_user` options, allowing bots to request to join a group/channel or to receive a user's contact information. The ReplyButton struct has been updated to incorporate User and Chat objects. Monitoring for updates when a chat or user is shared with the bot is now part of the ProcessUpdate function's responsibilities.