### PR TITLE
callback: add missing struct fields

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -26,13 +26,13 @@ type Callback struct {
 	// a bad client can send arbitrary data in this field.
 	Data string `json:"data"`
 
-	// Global identifier, uniquely corresponding to the chat to
-	// which the message with the callback button was sent.
+	// ChatInstance is a global identifier, uniquely corresponding to
+	// the chat to which the message with the callback button was sent.
 	ChatInstance string `json:"chat_instance"`
 
-	// Unique identifier of the game for which a URL is requested
-	// from the bot when a user presses the Play button of that game.
-	// GameShortName may be empty
+	// GameShortName is a unique identifier of the game for which a URL
+	// is requested from the bot when a user presses the Play button of
+	// that game. GameShortName may be empty
 	GameShortName string `json:"game_short_name"`
 
 	// Unique displays an unique of the button from which the

--- a/callback.go
+++ b/callback.go
@@ -26,6 +26,15 @@ type Callback struct {
 	// a bad client can send arbitrary data in this field.
 	Data string `json:"data"`
 
+	// Global identifier, uniquely corresponding to the chat to
+	// which the message with the callback button was sent.
+	ChatInstance string `json:"chat_instance"`
+
+	// Unique identifier of the game for which a URL is requested
+	// from the bot when a user presses the Play button of that game.
+	// GameShortName may be empty
+	GameShortName string `json:"game_short_name"`
+
 	// Unique displays an unique of the button from which the
 	// callback was fired. Sets immediately before the handling,
 	// while the Data field stores only with payload.


### PR DESCRIPTION
The telegram Bot API includes `chat_instance` and `game_short_name` in its [CallbackQuery object](https://core.telegram.org/bots/api#callbackquery). Particularly, the `game_short_name` is currently missing in the `Callback` object of the update when a user requests a game's url from the bot and it's also not deserialized in the `Game` object of the callback's message. 

I think it might be nice to have the Callback struct conforming with Telegram's CallbackQuery object and also a lot easier to implement than somehow populating the Game struct in the [message](https://github.com/tucnak/telebot/blob/71ac2995cc5d7379c35fceb3b64ce2c693e79e0c/message.go#L134).