### PR TITLE
inline: add game result support

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -131,6 +131,8 @@ func inferIQR(result Result) error {
 		r.Type = "voice"
 	case *StickerResult:
 		r.Type = "sticker"
+	case *GameResult:
+		r.Type = "game"
 	default:
 		return fmt.Errorf("telebot: result %v is not supported", result)
 	}

--- a/inline_types.go
+++ b/inline_types.go
@@ -60,12 +60,14 @@ func (r *ResultBase) Process(b *Bot) {
 	}
 }
 
-// GameResult represents a game.
+// GameResult represents a game. Game is a content type
+// supported by Telegram, which can be sent back to the
+// user as a result for an inline query.
 type GameResult struct {
 	ResultBase
 
-	// Unique identifier of the game.
-	GameShortName string `json:"game_short_name"`
+	// ShortName is a unique identifier of the game.
+	ShortName string `json:"game_short_name"`
 }
 
 // ArticleResult represents a link to an article or web page.

--- a/inline_types.go
+++ b/inline_types.go
@@ -60,6 +60,14 @@ func (r *ResultBase) Process(b *Bot) {
 	}
 }
 
+// GameResult represents a game.
+type GameResult struct {
+	ResultBase
+
+	// Unique identifier of the game.
+	GameShortName string `json:"game_short_name"`
+}
+
 // ArticleResult represents a link to an article or web page.
 type ArticleResult struct {
 	ResultBase


### PR DESCRIPTION
[Game](https://core.telegram.org/bots/api#inlinequeryresultgame) is one of the possible types a bot can send as inline query result. 