### PR TITLE
context: improve message args parsing

### DIFF
--- a/context.go
+++ b/context.go
@@ -355,7 +355,7 @@ func (c *nativeContext) Args() []string {
 	case c.u.Message != nil:
 		payload := strings.Trim(c.u.Message.Payload, " ")
 		if payload != "" {
-			return strings.Split(payload, " ")
+			return strings.Fields(payload)
 		}
 	case c.u.Callback != nil:
 		return strings.Split(c.u.Callback.Data, "|")


### PR DESCRIPTION
This is achieved by using strings.Fields instead of strings.Split

This results in a cleaner output when parsing messages like `/tags a          lot         of        spaces`

Output before: `[]string{"a", "", "", "", "", "", "", "", "", "", "lot", "", "", "", "", "", "", "", "", "of", "", "", "", "", "", "", "", "spaces"}`

Output after the change: `[]string{"a", "lot", "of", "spaces"}`