### PR TITLE
cache: feat cache contract and inmemory cache provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ By default, is in memory, can be implemented redis, mecmached, etc.
 // to store a cache of user state, inline results
 // for a Telegram bot.
 type Cache interface {
-	Get(key string) (interface{}, error)
-	Set(key string, value interface{}) error
+	Get(kind CacheKind, key string) (interface{}, error)
+	Set(kind CacheKind, key string, value interface{}) error
+	Clear(kind CacheKind, key string) error
 	
-	Keys() []string
+	Keys(kind CacheKind) []string
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,33 @@ if you'd like to see some endpoint or endpoint ideas implemented. This system
 is completely extensible, so I can introduce them without breaking
 backwards compatibility.
 
+## Cache
+
+Cache is a provider for cache that provides a contract to work with external storage.
+By default, is in memory, can be implemented redis, mecmached, etc.
+
+```go
+// Cache is a provider for cache
+//
+// All cache providers must implement methods, which work with storage
+// to store a cache of user state, inline results
+// for a Telegram bot.
+type Cache interface {
+	Get(key string) (interface{}, error)
+	Set(key string, value interface{}) error
+	
+	Keys() []string
+}
+```
+
+To store context to cache, could be used cache context middleware.
+
+```go
+cache := tele.NewInMemoryCache()
+
+b.Use(middleware.CacheContext(cache))
+```
+
 ## Context
 Context is a special type that wraps a huge update structure and represents
 the context of the current event. It provides several helpers, which allow

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,57 @@
+package telebot
+
+import (
+	"sync"
+)
+
+// Cache is a provider for cache
+//
+// All cache providers must implement methods, which work with storage
+// to store a cache of user state, inline results
+// for a Telegram bot.
+type Cache interface {
+	Get(key string) (interface{}, error)
+	Set(key string, value interface{}) error
+
+	Keys() []string
+}
+
+// InMemoryCache is a provider of in memory cache.
+//
+// Would be enabled by default
+type inMemoryCache struct {
+	lock sync.RWMutex
+	data map[string]interface{}
+
+	keys         []string // To maintain order of keys
+	currentIndex int      // To keep track of current index
+}
+
+func NewInMemoryCache() Cache {
+	return &inMemoryCache{}
+}
+
+func (m *inMemoryCache) Get(key string) (interface{}, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.data[key], nil
+}
+
+func (m *inMemoryCache) Set(key string, value interface{}) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.data == nil {
+		m.data = make(map[string]interface{})
+	}
+	m.data[key] = value
+	m.keys = append(m.keys, key) // Update the keys slice
+
+	return nil
+}
+
+func (m *inMemoryCache) Keys() []string {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.keys
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -9,23 +9,23 @@ import (
 func TestInMemoryCache_Get(t *testing.T) {
 	mc := NewInMemoryCache()
 
-	test, _ := mc.Get("test")
+	test, _ := mc.Get(CacheUserContext, "test")
 	assert.Equal(t, nil, test)
 }
 
 func TestInMemoryCache_Set(t *testing.T) {
 	mc := NewInMemoryCache()
 
-	_ = mc.Set("test", "test")
-	test, _ := mc.Get("test")
+	_ = mc.Put(CacheUserContext, "test", "test")
+	test, _ := mc.Get(CacheUserContext, "test")
 	assert.Equal(t, "test", test)
 }
 
 func TestInMemoryCache_Keys(t *testing.T) {
 	mc := NewInMemoryCache()
 
-	_ = mc.Set("test", "test")
+	_ = mc.Put(CacheUserContext, "test", "test")
 
-	keys := mc.Keys()
+	keys := mc.Keys(CacheUserContext)
 	assert.Equal(t, []string{"test"}, keys)
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,31 @@
+package telebot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInMemoryCache_Get(t *testing.T) {
+	mc := NewInMemoryCache()
+
+	test, _ := mc.Get("test")
+	assert.Equal(t, nil, test)
+}
+
+func TestInMemoryCache_Set(t *testing.T) {
+	mc := NewInMemoryCache()
+
+	_ = mc.Set("test", "test")
+	test, _ := mc.Get("test")
+	assert.Equal(t, "test", test)
+}
+
+func TestInMemoryCache_Keys(t *testing.T) {
+	mc := NewInMemoryCache()
+
+	_ = mc.Set("test", "test")
+
+	keys := mc.Keys()
+	assert.Equal(t, []string{"test"}, keys)
+}

--- a/context.go
+++ b/context.go
@@ -157,6 +157,9 @@ type Context interface {
 
 	// Set saves data in the context.
 	Set(key string, val interface{})
+
+	// Keys retrieves store keys
+	Keys() []string
 }
 
 // nativeContext is a native implementation of the Context interface.
@@ -502,4 +505,16 @@ func (c *nativeContext) Get(key string) interface{} {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.store[key]
+}
+
+func (c *nativeContext) Keys() []string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	keys := make([]string, 0, len(c.store))
+	for k := range c.store {
+		keys = append(keys, k)
+	}
+
+	return keys
 }

--- a/middleware/cache.go
+++ b/middleware/cache.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"log"
+
+	tele "gopkg.in/telebot.v3"
+)
+
+// CacheContext returns a middleware that store context to cache and retreive data from cache to context
+// If no custom cache provided, context store will be rested each iteration.
+func CacheContext(cache tele.Cache) tele.MiddlewareFunc {
+	return func(next tele.HandlerFunc) tele.HandlerFunc {
+		return func(ctx tele.Context) error {
+			for _, key := range cache.Keys() {
+				value, err := cache.Get(key)
+				if err != nil {
+					log.Printf("err: %s was happened, %s -> %s was not got from cache", err, value, key)
+
+					return err
+				}
+
+				ctx.Set(key, value)
+			}
+
+			defer func() {
+				for _, key := range ctx.Keys() {
+					value := ctx.Get(key)
+					err := cache.Set(key, value)
+					if err != nil {
+						log.Printf("err: %s was happened, %s -> %s was not stored from context", err, value, key)
+					}
+				}
+			}()
+
+			return next(ctx)
+		}
+	}
+}

--- a/middleware/cache.go
+++ b/middleware/cache.go
@@ -11,8 +11,8 @@ import (
 func CacheContext(cache tele.Cache) tele.MiddlewareFunc {
 	return func(next tele.HandlerFunc) tele.HandlerFunc {
 		return func(ctx tele.Context) error {
-			for _, key := range cache.Keys() {
-				value, err := cache.Get(key)
+			for _, key := range cache.Keys(tele.CacheUserContext) {
+				value, err := cache.Get(tele.CacheUserContext, key)
 				if err != nil {
 					log.Printf("err: %s was happened, %s -> %s was not got from cache", err, value, key)
 
@@ -25,7 +25,7 @@ func CacheContext(cache tele.Cache) tele.MiddlewareFunc {
 			defer func() {
 				for _, key := range ctx.Keys() {
 					value := ctx.Get(key)
-					err := cache.Set(key, value)
+					err := cache.Put(tele.CacheUserContext, key, value)
 					if err != nil {
 						log.Printf("err: %s was happened, %s -> %s was not stored from context", err, value, key)
 					}


### PR DESCRIPTION
The try to implement cache contract like was described in issue #287

The contract with cache was created to work with cache.
To work with cache was added in memory provider and an example of middleware that stores context to cache.

Let's discuss if it could be included in a telebot package.