### PR TITLE
fix: params[spoiler] > params[has_spoiler]

### DIFF
--- a/options.go
+++ b/options.go
@@ -204,7 +204,7 @@ func (b *Bot) embedSendOptions(params map[string]string, opt *SendOptions) {
 	}
 
 	if opt.HasSpoiler {
-		params["spoiler"] = "true"
+		params["has_spoiler"] = "true"
 	}
 }
 


### PR DESCRIPTION
From the official API doc of the Telegram, here should be has_spoiler instead of spoiler 