### PR TITLE
feat: download to writer for medias.

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -903,6 +903,25 @@ func (b *Bot) Download(file *File, localFilename string) error {
 	return nil
 }
 
+// DownloadToWriter stream the file from Telegram servers to an io.Writer interface,
+// This can be used for cases that you want to get the file from one server,
+// and directly upload it to another server without saving it locally.
+// Maximum file size to download is 20 MB.
+func (b *Bot) DownloadToWriter(file *File, writer io.Writer) error {
+	reader, err := b.File(file)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	_, err = io.Copy(writer, reader)
+	if err != nil {
+		return wrapError(err)
+	}
+
+	return nil
+}
+
 // File gets a file from Telegram servers.
 func (b *Bot) File(file *File) (io.ReadCloser, error) {
 	f, err := b.FileByID(file.FileID)


### PR DESCRIPTION
In case of `(b *Bot) Download(file *File, localFilename string) error` function, users may need different actions than just saving the file automatically on disk, e.g.
- storing the file on minio, s3, etc.
- piping the file to a request to another service
- piping the file to an AI model
- making the file on the disk however the user wants.

Having another DownloadToWriter method that accepts any kind of `io.Writer` will help users skip an extra step to save on disk and read from the disk.