### PR TITLE
BUG: reactions count bug

### DIFF
--- a/message.go
+++ b/message.go
@@ -551,7 +551,7 @@ type MessageReactionCount struct {
 	DateUnixtime int64 `json:"date"`
 
 	// List of reactions that are present on the message.
-	Reactions *ReactionCount `json:"reactions"`
+	Reactions []*ReactionCount `json:"reactions"`
 }
 
 // Time returns the moment of change in local time.


### PR DESCRIPTION
On updates of post reactions I've got error: `json: cannot unmarshal array into Go struct field MessageReactionCount.Result.message_reaction_count.reactions of type telebot.ReactionCount]`

I've found, if you use "message_reaction" allowed_updates, that `message_reaction_count.reactions` came as list, not just one.

I can't be sure that this will be the same for all cases, but it is in mine.
