### PR TITLE
fix missing Caption on Photo unmarshalling

### DIFF
--- a/media.go
+++ b/media.go
@@ -119,6 +119,7 @@ func (p *Photo) UnmarshalJSON(data []byte) error {
 	p.File = hq.File
 	p.Width = hq.Width
 	p.Height = hq.Height
+	p.Caption = hq.Caption
 
 	return nil
 }


### PR DESCRIPTION
Fixes new Photos (e.g. loaded from disk) marshalled to json and then unmarshalled back with Photo.UnmarshallJSON missing Caption field.