### PR TITLE
 Add structured unknown error from telegram api

### DIFF
--- a/bot_raw.go
+++ b/bot_raw.go
@@ -330,14 +330,11 @@ func extractOk(data []byte) error {
 			err:        NewError(e.Code, e.Description),
 			RetryAfter: int(retryAfter.(float64)),
 		}
-	case http.StatusBadRequest:
+	default:
 		err = &Error{
 			Code:        e.Code,
 			Description: e.Description,
 		}
-
-	default:
-		err = fmt.Errorf("telegram: %s (%d)", e.Description, e.Code)
 	}
 
 	return err

--- a/bot_raw.go
+++ b/bot_raw.go
@@ -330,6 +330,12 @@ func extractOk(data []byte) error {
 			err:        NewError(e.Code, e.Description),
 			RetryAfter: int(retryAfter.(float64)),
 		}
+	case http.StatusBadRequest:
+		err = &Error{
+			Code:        e.Code,
+			Description: e.Description,
+		}
+
 	default:
 		err = fmt.Errorf("telegram: %s (%d)", e.Description, e.Code)
 	}

--- a/bot_raw_test.go
+++ b/bot_raw_test.go
@@ -107,6 +107,15 @@ func TestExtractOk(t *testing.T) {
 		err:        ErrGroupMigrated,
 		MigratedTo: -100123456789,
 	}, extractOk(data))
+
+	data = []byte(`{
+		"ok": false,
+		"error_code": 400,
+		"description": "Bad Request: can't parse entities: Can't find end tag corresponding to start tag \"b\""
+	}`)
+	assert.Equal(t, &Error{Code: 400, Description: `Bad Request: can't parse entities: Can't find end tag corresponding to start tag "b"`},
+		extractOk(data))
+
 }
 
 func TestExtractMessage(t *testing.T) {


### PR DESCRIPTION
There are cases when api telegram returns errors that do not have static text, for example: 
```
Bad Request: can't parse entities: Can't find end tag corresponding to start tag "b"
```

In this case, it is impossible to determine on the library user side that this error is a Bad Request, as it will be generic and will only contain the error text

This PR solves this problem and allows to handle such errors as follows:
```
	var e *telebot.Error
	if errors.As(err, &e) {
		if e.Code == 400 {
			...
		}
	}
```

Errors that were previously predefined as bad request will be handled in the same form