### PR TITLE
FIX: keep order of commands, better docs

### DIFF
--- a/layout/example.yml
+++ b/layout/example.yml
@@ -6,6 +6,7 @@ settings:
 commands:
   /start: Start the bot
   /help: How to use the bot
+  /settings: "{{ text `cmd_settings` }}"
 
 config:
   str: string
@@ -22,7 +23,6 @@ config:
     - <<: *obj
     - <<: *obj
 
-
 buttons:
   # Shortened reply buttons
   help: Help
@@ -37,16 +37,16 @@ buttons:
   stop:
     unique: stop
     text: Stop
-    data: '{{.}}'
+    data: "{{.}}"
 
   # Callback data
   pay:
     unique: pay
     text: Pay
     data:
-      - '{{ .UserID }}'
-      - '{{ .Amount }}'
-      - '{{ .Currency }}'
+      - "{{ .UserID }}"
+      - "{{ .Amount }}"
+      - "{{ .Currency }}"
 
   web_app:
     text: This is a web app
@@ -55,22 +55,22 @@ buttons:
 
 markups:
   reply_shortened:
-    - [ help ]
-    - [ settings ]
+    - [help]
+    - [settings]
   reply_extended:
     keyboard:
-      - [ contact ]
+      - [contact]
     one_time_keyboard: true
   inline:
-    - [ stop ]
+    - [stop]
   web_app:
-    - [ web_app ]
+    - [web_app]
 
 results:
   article:
     type: article
-    id: '{{ .ID }}'
-    title: '{{ .Title }}'
-    description: '{{ .Description }}'
-    thumbnail_url: '{{ .PreviewURL }}'
-    message_text: '{{ text `article_message` }}'
+    id: "{{ .ID }}"
+    title: "{{ .Title }}"
+    description: "{{ .Description }}"
+    thumbnail_url: "{{ .PreviewURL }}"
+    message_text: "{{ text `article_message` }}"

--- a/layout/example.yml
+++ b/layout/example.yml
@@ -23,6 +23,7 @@ config:
     - <<: *obj
     - <<: *obj
 
+
 buttons:
   # Shortened reply buttons
   help: Help
@@ -37,16 +38,16 @@ buttons:
   stop:
     unique: stop
     text: Stop
-    data: "{{.}}"
+    data: '{{.}}'
 
   # Callback data
   pay:
     unique: pay
     text: Pay
     data:
-      - "{{ .UserID }}"
-      - "{{ .Amount }}"
-      - "{{ .Currency }}"
+      - '{{ .UserID }}'
+      - '{{ .Amount }}'
+      - '{{ .Currency }}'
 
   web_app:
     text: This is a web app
@@ -55,22 +56,22 @@ buttons:
 
 markups:
   reply_shortened:
-    - [help]
-    - [settings]
+    - [ help ]
+    - [ settings ]
   reply_extended:
     keyboard:
-      - [contact]
+      - [ contact ]
     one_time_keyboard: true
   inline:
-    - [stop]
+    - [ stop ]
   web_app:
-    - [web_app]
+    - [ web_app ]
 
 results:
   article:
     type: article
-    id: "{{ .ID }}"
-    title: "{{ .Title }}"
-    description: "{{ .Description }}"
-    thumbnail_url: "{{ .PreviewURL }}"
-    message_text: "{{ text `article_message` }}"
+    id: '{{ .ID }}'
+    title: '{{ .Title }}'
+    description: '{{ .Description }}'
+    thumbnail_url: '{{ .PreviewURL }}'
+    message_text: '{{ text `article_message` }}'

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -200,9 +200,9 @@ func (lt *Layout) Commands() (cmds []tele.Command) {
 //
 // Usage:
 //
-// b.SetCommands(lt.CommandsLocale("en"), "en")
-// b.SetCommands(lt.CommandsLocale("ru"), "ru")
-// b.SetCommands(lt.CommandsLocale("en"))
+//	b.SetCommands(lt.CommandsLocale("en"), "en")
+//	b.SetCommands(lt.CommandsLocale("ru"), "ru")
+//	b.SetCommands(lt.CommandsLocale("en"))
 func (lt *Layout) CommandsLocale(locale string, args ...interface{}) (cmds []tele.Command) {
 	var arg interface{}
 	if len(args) > 0 {

--- a/layout/layout_test.go
+++ b/layout/layout_test.go
@@ -32,13 +32,26 @@ func TestLayout(t *testing.T) {
 	assert.Equal(t, &tele.LongPoller{}, pref.Poller)
 	assert.Equal(t, pref, ltfs.Settings())
 
-	assert.ElementsMatch(t, []tele.Command{{
+	assert.Equal(t, []tele.Command{{
 		Text:        "start",
 		Description: "Start the bot",
 	}, {
 		Text:        "help",
 		Description: "How to use the bot",
+	}, {
+		Text:        "settings",
+		Description: "{{ text `cmd_settings` }}",
 	}}, lt.Commands())
+	assert.Equal(t, []tele.Command{{
+		Text:        "start",
+		Description: "Start the bot",
+	}, {
+		Text:        "help",
+		Description: "How to use the bot",
+	}, {
+		Text:        "settings",
+		Description: "Settings",
+	}}, lt.CommandsLocale("en"))
 
 	assert.Equal(t, "string", lt.String("str"))
 	assert.Equal(t, 123, lt.Int("num"))

--- a/layout/locales/en.yml
+++ b/layout/locales/en.yml
@@ -6,3 +6,5 @@ nested:
   another:
     example: |-
       This is {{ . }}.
+
+cmd_settings: Settings

--- a/layout/parser.go
+++ b/layout/parser.go
@@ -30,7 +30,7 @@ func (lt *Layout) UnmarshalYAML(data []byte) error {
 	var aux struct {
 		Settings *Settings
 		Config   map[string]interface{}
-		Commands map[string]string
+		Commands yaml.MapSlice
 		Buttons  yaml.MapSlice
 		Markups  yaml.MapSlice
 		Results  yaml.MapSlice
@@ -46,7 +46,22 @@ func (lt *Layout) UnmarshalYAML(data []byte) error {
 	}
 
 	lt.Config = Config{v: v}
-	lt.commands = aux.Commands
+	lt.commands = make([]tele.Command, 0, len(aux.Commands))
+	for _, cmd := range aux.Commands {
+		var (
+			text        string
+			description string
+			ok          bool
+		)
+
+		if text, ok = cmd.Key.(string); !ok {
+			continue
+		}
+		if description, ok = cmd.Value.(string); !ok {
+			continue
+		}
+		lt.commands = append(lt.commands, tele.Command{Text: strings.TrimLeft(text, "/"), Description: description})
+	}
 
 	if pref := aux.Settings; pref != nil {
 		lt.pref = &tele.Settings{


### PR DESCRIPTION
Came across some difficulties when used layout, one of that is commands usage:

every restart I have different set of commands, owning to it is map (made it list)
not obvious to find way of templating commands (added to example.yml) and tests
not obvious how to use SetCommands for all not specified locales (added it in layout docstring)

Previous try https://github.com/tucnak/telebot/pull/681 