### PR TITLE
Add `Settings.TestAPI` flag to enable using the Telegram test API

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -36,11 +36,17 @@ func NewBot(pref Settings) (*Bot, error) {
 		pref.OnError = defaultOnError
 	}
 
+	testApiPath := ""
+	if pref.TestAPI {
+		testApiPath = "/test"
+	}
+
 	bot := &Bot{
-		Token:   pref.Token,
-		URL:     pref.URL,
-		Poller:  pref.Poller,
-		onError: pref.OnError,
+		Token:       pref.Token,
+		URL:         pref.URL,
+		TestApiPath: testApiPath,
+		Poller:      pref.Poller,
+		onError:     pref.OnError,
 
 		Updates:  make(chan Update, pref.Updates),
 		handlers: make(map[string]HandlerFunc),
@@ -68,12 +74,13 @@ func NewBot(pref Settings) (*Bot, error) {
 
 // Bot represents a separate Telegram bot instance.
 type Bot struct {
-	Me      *User
-	Token   string
-	URL     string
-	Updates chan Update
-	Poller  Poller
-	onError func(error, Context)
+	Me          *User
+	Token       string
+	URL         string
+	TestApiPath string
+	Updates     chan Update
+	Poller      Poller
+	onError     func(error, Context)
 
 	group       *Group
 	handlers    map[string]HandlerFunc
@@ -92,6 +99,9 @@ type Bot struct {
 type Settings struct {
 	URL   string
 	Token string
+
+	// TestAPI enables using the test API server.
+	TestAPI bool
 
 	// Updates channel capacity, defaulted to 100.
 	Updates int
@@ -957,7 +967,7 @@ func (b *Bot) File(file *File) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	url := b.URL + "/file/bot" + b.Token + "/" + f.FilePath
+	url := b.URL + "/file/bot" + b.Token + b.TestApiPath + "/" + f.FilePath
 	file.FilePath = f.FilePath // saving file path
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)

--- a/bot_raw.go
+++ b/bot_raw.go
@@ -20,7 +20,7 @@ import (
 // It also handles API errors, so you only need to unwrap
 // result field from json data.
 func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
-	url := b.URL + "/bot" + b.Token + "/" + method
+	url := b.URL + "/bot" + b.Token + b.TestApiPath + "/" + method
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
@@ -116,7 +116,7 @@ func (b *Bot) sendFiles(method string, files map[string]File, params map[string]
 		}
 	}()
 
-	url := b.URL + "/bot" + b.Token + "/" + method
+	url := b.URL + "/bot" + b.Token + b.TestApiPath + "/" + method
 
 	resp, err := b.client.Post(url, writer.FormDataContentType(), pipeReader)
 	if err != nil {


### PR DESCRIPTION
This PR add the capability to use the Telegram test API in order to help with bot development. The test API setup is describe in the official documentation here https://core.telegram.org/bots/features#creating-a-bot-in-the-test-environment.

After having created a bot in the Telegram test environment you can now create the bot using the new `TestAPI` setting.

```go
pref := tele.Settings{
	Token:   telegramBotToken,
	TestAPI: true,
}

b, err := tele.NewBot(pref)
```

I tested this including the file API, I hope I did not missed anything.