### PR TITLE
context: inherit incoming message_thread_id by default

### DIFF
--- a/context.go
+++ b/context.go
@@ -424,12 +424,12 @@ func (c *nativeContext) Args() []string {
 }
 
 func (c *nativeContext) Send(what interface{}, opts ...interface{}) error {
-	c.inheritContextOpts(opts)
+	c.inheritOpts(opts)
 	_, err := c.b.Send(c.Recipient(), what, opts...)
 	return err
 }
 
-func (c *nativeContext) inheritContextOpts(opts ...interface{}) {
+func (c *nativeContext) inheritOpts(opts ...interface{}) {
 	var (
 		ignoreThread bool
 	)
@@ -461,7 +461,7 @@ func (c *nativeContext) Reply(what interface{}, opts ...interface{}) error {
 	if msg == nil {
 		return ErrBadContext
 	}
-	c.inheritContextOpts(opts)
+	c.inheritOpts(opts)
 	_, err := c.b.Reply(msg, what, opts...)
 	return err
 }
@@ -481,7 +481,7 @@ func (c *nativeContext) ForwardTo(to Recipient, opts ...interface{}) error {
 }
 
 func (c *nativeContext) Edit(what interface{}, opts ...interface{}) error {
-	c.inheritContextOpts(opts)
+	c.inheritOpts(opts)
 
 	if c.u.InlineResult != nil {
 		_, err := c.b.Edit(c.u.InlineResult, what, opts...)
@@ -495,7 +495,7 @@ func (c *nativeContext) Edit(what interface{}, opts ...interface{}) error {
 }
 
 func (c *nativeContext) EditCaption(caption string, opts ...interface{}) error {
-	c.inheritContextOpts(opts)
+	c.inheritOpts(opts)
 
 	if c.u.InlineResult != nil {
 		_, err := c.b.EditCaption(c.u.InlineResult, caption, opts...)

--- a/context.go
+++ b/context.go
@@ -424,8 +424,31 @@ func (c *nativeContext) Args() []string {
 }
 
 func (c *nativeContext) Send(what interface{}, opts ...interface{}) error {
+	c.inheritContextOpts(opts)
 	_, err := c.b.Send(c.Recipient(), what, opts...)
 	return err
+}
+
+func (c *nativeContext) inheritContextOpts(opts ...interface{}) {
+	var (
+		ignoreThread bool
+	)
+
+	for _, opt := range opts {
+		switch opt.(type) {
+		case Option:
+			switch opt {
+			case IgnoreThread:
+				ignoreThread = true
+			default:
+			}
+		}
+	}
+
+	switch {
+	case !ignoreThread && c.Message() != nil && c.Message().ThreadID != 0:
+		opts = append(opts, Topic{ThreadID: c.Message().ThreadID})
+	}
 }
 
 func (c *nativeContext) SendAlbum(a Album, opts ...interface{}) error {
@@ -438,6 +461,7 @@ func (c *nativeContext) Reply(what interface{}, opts ...interface{}) error {
 	if msg == nil {
 		return ErrBadContext
 	}
+	c.inheritContextOpts(opts)
 	_, err := c.b.Reply(msg, what, opts...)
 	return err
 }
@@ -457,6 +481,8 @@ func (c *nativeContext) ForwardTo(to Recipient, opts ...interface{}) error {
 }
 
 func (c *nativeContext) Edit(what interface{}, opts ...interface{}) error {
+	c.inheritContextOpts(opts)
+
 	if c.u.InlineResult != nil {
 		_, err := c.b.Edit(c.u.InlineResult, what, opts...)
 		return err
@@ -469,6 +495,8 @@ func (c *nativeContext) Edit(what interface{}, opts ...interface{}) error {
 }
 
 func (c *nativeContext) EditCaption(caption string, opts ...interface{}) error {
+	c.inheritContextOpts(opts)
+
 	if c.u.InlineResult != nil {
 		_, err := c.b.EditCaption(c.u.InlineResult, caption, opts...)
 		return err

--- a/options.go
+++ b/options.go
@@ -34,6 +34,9 @@ const (
 
 	// RemoveKeyboard = ReplyMarkup.RemoveKeyboard
 	RemoveKeyboard
+
+	// IgnoreThread is used to ignore the thread when responding to a message via context.
+	IgnoreThread
 )
 
 // Placeholder is used to set input field placeholder as a send option.
@@ -149,6 +152,8 @@ func (b *Bot) extractOptions(how []interface{}) *SendOptions {
 			opts.ParseMode = opt
 		case Entities:
 			opts.Entities = opt
+		case Topic:
+			opts.ThreadID = opt.ThreadID
 		default:
 			panic("telebot: unsupported send-option")
 		}


### PR DESCRIPTION
These changes will ensure that the bot responds to incoming messages within the same topic when using context.