### PR TITLE
api interface: add a trigger func

### DIFF
--- a/api.go
+++ b/api.go
@@ -6,6 +6,7 @@ import "io"
 // with Telegram Bot API.
 type API interface {
 	Raw(method string, payload interface{}) ([]byte, error)
+	Trigger(endpoint interface{}, c Context) error
 
 	Accept(query *PreCheckoutQuery, errorMessage ...string) error
 	AddStickerToSet(of Recipient, name string, sticker InputSticker) error


### PR DESCRIPTION
It could be useful in some scenarios when you want to trigger another handler from some specific handler, which doesn't have a link to a Bot struct, but has just a context provided.

For example:
```
func SomeHandlerFunc(c telebot.Context) error {
    // some business logic
    
   return c.Bot().Trigger("/another-command", c)
}
```

The original method was implemented here: https://github.com/tucnak/telebot/pull/687
