### PR TITLE
PR: Add protect_content support to Video and Photo messages

### DIFF
--- a/media.go
+++ b/media.go
@@ -3,6 +3,7 @@ package telebot
 import (
 	"encoding/json"
 	"math"
+
 )
 
 // Media is a generic type for all kinds of media that includes File.
@@ -75,6 +76,7 @@ type Photo struct {
 	Caption      string `json:"caption,omitempty"`
 	HasSpoiler   bool   `json:"has_spoiler,omitempty"`
 	CaptionAbove bool   `json:"show_caption_above_media,omitempty"`
+	ProtectContent bool   `json:"protect_content,omitempty"`
 }
 
 type photoSize struct {
@@ -209,13 +211,14 @@ type Video struct {
 	Duration int `json:"duration,omitempty"`
 
 	// (Optional)
-	Caption      string `json:"caption,omitempty"`
-	Thumbnail    *Photo `json:"thumbnail,omitempty"`
-	Streaming    bool   `json:"supports_streaming,omitempty"`
-	MIME         string `json:"mime_type,omitempty"`
-	FileName     string `json:"file_name,omitempty"`
-	HasSpoiler   bool   `json:"has_spoiler,omitempty"`
-	CaptionAbove bool   `json:"show_caption_above_media,omitempty"`
+	Caption        string `json:"caption,omitempty"`
+	Thumbnail      *Photo `json:"thumbnail,omitempty"`
+	Streaming      bool   `json:"supports_streaming,omitempty"`
+	MIME           string `json:"mime_type,omitempty"`
+	FileName       string `json:"file_name,omitempty"`
+	HasSpoiler     bool   `json:"has_spoiler,omitempty"`
+	CaptionAbove   bool   `json:"show_caption_above_media,omitempty"`
+	ProtectContent bool   `json:"protect_content,omitempty"`
 }
 
 func (v *Video) MediaType() string {

--- a/sendable.go
+++ b/sendable.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+
 )
 
 // Recipient is any possible endpoint you can send
@@ -29,7 +30,9 @@ func (p *Photo) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 		"caption": p.Caption,
 	}
 	b.embedSendOptions(params, opt)
-
+	if p.ProtectContent {
+		params["protect_content"] = "true"
+	}
 	msg, err := b.sendMedia(p, params, nil)
 	if err != nil {
 		return nil, err
@@ -138,7 +141,6 @@ func (v *Video) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 		"file_name": v.FileName,
 	}
 	b.embedSendOptions(params, opt)
-
 	if v.Duration != 0 {
 		params["duration"] = strconv.Itoa(v.Duration)
 	}
@@ -150,6 +152,9 @@ func (v *Video) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
 	}
 	if v.Streaming {
 		params["supports_streaming"] = "true"
+	}
+	if v.ProtectContent {
+		params["protect_content"] = "true"
 	}
 
 	msg, err := b.sendMedia(v, params, thumbnailToFilemap(v.Thumbnail))


### PR DESCRIPTION
This PR adds support for the protect_content field in SendVideo and SendPhoto requests. Setting this field to true ensures that the sent media is protected — i.e., it cannot be forwarded or saved by the recipient.

✅ What’s added 
- `ProtectContent bool json:"protect_content,omitempty"` field added to: 
    - Video 
    - Photo
- `protect_content` included in API request parameters when set to `true`.