### PR TITLE
flow v2

### DIFF
--- a/flow/bus.go
+++ b/flow/bus.go
@@ -1,0 +1,233 @@
+package flow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"gopkg.in/telebot.v4"
+	"gopkg.in/telebot.v4/flow/storage"
+	"strconv"
+	"time"
+)
+
+var (
+	NoStepsDefined = errors.New("flow: no steps defined")
+	IsExpired      = errors.New("flow: expired")
+)
+
+// Bus defines the methods for managing user flows.
+type Bus interface {
+	// Flow creates a new flow builder. The timeout defines how long the entire flow can run before expiring.
+	// If timeout is zero, the flow never expires.
+	Flow(name string, timeout time.Duration) *Flow
+
+	// Start initiates or resumes a flow for the user.
+	// Only one flow can be active per user at a time; if an existing flow is active, it resumes from its current step.
+	//
+	// Example:
+	//	bot.Handle("/signup", func(c tele.Context) error {
+	//		f := bus.Flow("signup", flow.DefaultTimeout)
+	//
+	//		f.OnText(func(state *flow.State) error {
+	//			// ..
+	//		}).Assign(func(state *flow.State) error {
+	//			// ..
+	//		}).Ok(func(state *flow.State) error {
+	//			// ..
+	//		})
+	//
+	//		return bus.Start(ctx,c, f)
+	//	})
+	Start(ctx context.Context, c telebot.Context, flow *Flow) error
+
+	// Handle processes incoming events and advances the flow state if applicable.
+	// Register this as a handler for relevant telebot events, e.g.:
+	//   bot.Handle(tele.OnText, bus.Handle)
+	//   bot.Handle(tele.OnCallback, bus.Handle)
+	Handle(telebot.Context) error
+}
+
+// state wraps the flow and its current state for storage.
+type state struct {
+	flow  *Flow
+	state *State
+}
+
+// bus implementation for the [Bus] contract.
+type bus struct {
+	// Stores the active user flows.
+	// userID -> state
+	//
+	// NOTE: Please check if your [storage.Storage] is secure to concurrency.
+	states storage.Storage
+}
+
+func (b *bus) Flow(name string, timeout time.Duration) *Flow {
+	return &Flow{
+		name:    name,
+		steps:   make([]*Step, 0),
+		timeout: timeout,
+	}
+}
+
+func (b *bus) Handle(c telebot.Context) error {
+	uid := strconv.FormatInt(c.Sender().ID, 10)
+
+	stValue, err := b.states.Get(uid)
+	if err != nil {
+		if errors.Is(err, storage.ErrKeyNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("flow: get stored value: %w", err)
+	}
+
+	if stValue == nil {
+		return nil
+	}
+
+	st := stValue.(*state)
+	if st.flow.IsExpired() {
+		if err = b.states.Delete(uid); err != nil {
+			return fmt.Errorf("flow: failed to remove expired state: %w", err)
+		}
+
+		return IsExpired
+	}
+
+	st.state.Context = c
+	step := st.flow.steps[st.state.Machine.ActiveStep()]
+
+	// checks if the event type matches the step's expected event.
+	event := b.getEventType(c)
+	if event != step.on || event == "" {
+		return nil
+	}
+
+	// call [validatorFns] event if it's defined.
+	for _, fn := range step.validatorsFns {
+		handler := fn(st.state)
+		if handler != nil {
+			if err = handler(c); err != nil {
+				return fmt.Errorf("flow: failed to execute validator func: %w", err)
+			}
+		}
+	}
+
+	// call [assignFn] event if it's defined.
+	if step.assignFn != nil {
+		if err = step.assignFn(st.state); err != nil {
+			return fmt.Errorf("flow: failed to assign step: %w", err)
+		}
+	}
+
+	// call [okFn] event if it's defined.
+	if step.okFn != nil {
+		if err := step.okFn(st.state); err != nil {
+			return fmt.Errorf("flow: failed to ok step: %w", err)
+		}
+	}
+
+	// it was the last step.
+	if len(st.flow.steps) <= st.state.Machine.ActiveStep()+1 {
+		if err = b.states.Delete(uid); err != nil {
+			return fmt.Errorf("flow: failed to remove completed state: %w", err)
+		}
+
+		// always call the [ok] handler if the flow is finished.
+		return st.state.Machine.Ok(st.state)
+	}
+
+	// process to the next step
+	err = st.state.Machine.Next(st.state)
+	if err != nil {
+		// in case of any error, we delete the current status from the user.
+		if delErr := b.states.Delete(uid); delErr != nil {
+			return fmt.Errorf("flow: failed to remove state on error: %w (original err: %v)", delErr, err)
+		}
+
+		// always call the [error] if err !=.
+		return st.state.Machine.Fail(st.state, err)
+	}
+
+	return nil
+}
+
+func (b *bus) Start(ctx context.Context, c telebot.Context, flow *Flow) error {
+	if len(flow.steps) == 0 {
+		return NoStepsDefined
+	}
+
+	uid := strconv.FormatInt(c.Sender().ID, 10)
+
+	// if the user already has a flow, we need to recall the active step.
+	stV, _ := b.states.Get(uid)
+	if stV != nil {
+		st := stV.(*state)
+		st.state.Context = c
+		if st.flow.IsExpired() {
+			if err := b.states.Delete(uid); err != nil {
+				return fmt.Errorf("flow: failed to remove expired state: %w", err)
+			}
+			return IsExpired
+		}
+
+		return st.state.Machine.ToStep(st.state.Machine.ActiveStep(), st.state)
+	}
+
+	machine := NewMachine(flow)
+
+	// register flow for the user.
+	st := state{
+		flow:  flow,
+		state: NewState(machine, c),
+	}
+	// set start time when actually starting.
+	flow.start = time.Now()
+
+	if err := b.states.Set(ctx, strconv.FormatInt(c.Sender().ID, 10), &st, flow.timeout); err != nil {
+		return fmt.Errorf("flow: failed to set state: %w", err)
+	}
+
+	// call the machine for the start the first step.
+	return machine.ToStep(0, st.state)
+}
+
+// getEventType determines the telebot event type from the context.
+func (b *bus) getEventType(c telebot.Context) string {
+	if c.Message().Text != "" {
+		return telebot.OnText
+	}
+	if c.Callback() != nil {
+		return telebot.OnCallback
+	}
+	if c.Message().Audio != nil {
+		return telebot.OnAudio
+	}
+	if c.Message().Document != nil {
+		return telebot.OnDocument
+	}
+	if c.Message().Video != nil {
+		return telebot.OnVideo
+	}
+	if c.Message().Voice != nil {
+		return telebot.OnVoice
+	}
+	if c.Message().Contact != nil {
+		return telebot.OnContact
+	}
+	if c.Message().Location != nil {
+		return telebot.OnLocation
+	}
+
+	return ""
+}
+
+// NewBus constructor [Bus].
+//
+// NOTE: Please check if your [storage.Storage] is secure to concurrency.
+func NewBus(states storage.Storage) Bus {
+	return &bus{
+		states: states,
+	}
+}

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -1,0 +1,104 @@
+package flow
+
+import (
+	tele "gopkg.in/telebot.v4"
+	"sync"
+	"time"
+)
+
+// Flow is a builder for defining a sequence of steps in a user interaction flow.
+type Flow struct {
+	name string
+
+	steps []*Step
+
+	okFn  StateHandler
+	errFn ErrHandler
+
+	timeout time.Duration
+	start   time.Time
+
+	mu sync.RWMutex
+}
+
+// OnText adds a step that triggers on text messages.
+func (f *Flow) OnText(beginFn StateHandler) *Step {
+	return f.addStep(tele.OnText, beginFn)
+}
+
+// OnCallback adds a step that triggers on callback queries.
+func (f *Flow) OnCallback(beginFn StateHandler) *Step {
+	return f.addStep(tele.OnCallback, beginFn)
+}
+
+// OnPhoto adds a step that triggers on photo messages.
+func (f *Flow) OnPhoto(beginFn StateHandler) *Step {
+	return f.addStep(tele.OnPhoto, beginFn)
+}
+
+// OnAudio adds a step that triggers on audio messages.
+func (f *Flow) OnAudio(beginFn StateHandler) *Step {
+	return f.addStep(tele.OnAudio, beginFn)
+}
+
+// OnDocument adds a step that triggers on document messages.
+func (f *Flow) OnDocument(beginFn StateHandler) *Step {
+	return f.addStep(tele.OnDocument, beginFn)
+}
+
+// OnVideo adds a step that triggers on video messages.
+func (f *Flow) OnVideo(beginFn StateHandler) *Step {
+	return f.addStep(tele.OnVideo, beginFn)
+}
+
+// OnVoice adds a step that triggers on voice messages.
+func (f *Flow) OnVoice(beginFn StateHandler) *Step {
+	return f.addStep(tele.OnVoice, beginFn)
+}
+
+// OnContact adds a step that triggers on contact messages.
+func (f *Flow) OnContact(beginFn StateHandler) *Step {
+	return f.addStep(tele.OnContact, beginFn)
+}
+
+// OnLocation adds a step that triggers on location messages.
+func (f *Flow) OnLocation(beginFn StateHandler) *Step {
+	return f.addStep(tele.OnLocation, beginFn)
+}
+
+func (f *Flow) addStep(on string, beginFn StateHandler) *Step {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	// simple autoincrement.
+	id := len(f.steps)
+
+	step := &Step{
+		id:      id,
+		on:      on,
+		beginFn: beginFn,
+	}
+	f.steps = append(f.steps, step)
+
+	return step
+}
+
+// Ok sets the handler called when the entire flow completes successfully.
+func (f *Flow) Ok(fn StateHandler) *Flow {
+	f.okFn = fn
+	return f
+}
+
+// Err sets the handler called when the flow fails.
+func (f *Flow) Err(fn ErrHandler) *Flow {
+	f.errFn = fn
+	return f
+}
+
+// IsExpired checks if the flow has timed out since starting.
+func (f *Flow) IsExpired() bool {
+	if f.timeout == 0 {
+		return false
+	}
+	return time.Since(f.start) > f.timeout
+}

--- a/flow/state.go
+++ b/flow/state.go
@@ -1,0 +1,28 @@
+package flow
+
+import (
+	tele "gopkg.in/telebot.v4"
+)
+
+// StateHandler is a function that handles a state transition or action.
+type StateHandler func(state *State) error
+
+// ValidateHandler is a function for validation data from [tele.Context].
+type ValidateHandler func(state *State) tele.HandlerFunc
+
+// ErrHandler handles flow errors.
+type ErrHandler func(*State, error) error
+
+// State holds the current [Machine] and [tele.Context] for a flow step.
+type State struct {
+	Machine Machine
+	Context tele.Context
+}
+
+// NewState constructor [State].
+func NewState(machine Machine, c tele.Context) *State {
+	return &State{
+		Machine: machine,
+		Context: c,
+	}
+}

--- a/flow/step.go
+++ b/flow/step.go
@@ -1,0 +1,91 @@
+package flow
+
+// Step defines users step in [Flow].
+type Step struct {
+	// Step id (default autoincrement). (Required)
+	id int
+
+	// TODO: Maybe add `name` field for detail logging?
+
+	// Basic message handlers [tele.OnText, tele.OnCallback, tele.OnAudio, etc]. (Required)
+	// https://github.com/tucnak/telebot/blob/v4/telebot.go
+	on string
+
+	// Callback called at the beginning of the step.
+	// It is mainly used to encourage the user to take action.
+	//
+	// Example:
+	//		flow.OnText(func(state *flow.State) error {
+	//			return state.Context.Send("Enter username:")
+	//		})
+	beginFn StateHandler
+
+	// Callback called after [beginFn].
+	// It is intended for validation only.
+	//
+	// Example:
+	//	f.OnText(func(state *flow.State) error {
+	//			return state.Context.EditOrSend("Enter username:")
+	//		}).Validations(func(state *flow.State) tele.HandlerFunc {
+	//			data := state.Context.Message().Text
+	//			if len(data) > 10 {
+	//				return func(c tele.Context) error {
+	//					return c.EditOrSend("username max length 10, please check data and send me")
+	//				}
+	//			}
+	//			return nil
+	//		})
+	validatorsFns []ValidateHandler
+
+	// Callback called after validation.
+	// It can, for example, assign the user's result to a variable.
+	//
+	// Example:
+	// 		var username string
+	//
+	//		f.OnText(func(state *flow.State) error {
+	//			return state.Context.EditOrSend("Enter username:")
+	//		}).Validations(func(state *flow.State) tele.HandlerFunc {
+	//          // ...
+	//		}).Assign(func(state *flow.State) error {
+	//			username = state.Context.Message().Text
+	//			return nil
+	//		})
+	assignFn StateHandler
+
+	// Callback called after [assignFn].
+	// Example:
+	// 		var username string
+	//
+	//		f.OnText(func(state *flow.State) error {
+	//			return state.Context.EditOrSend("Enter username:")
+	//		}).Validations(func(state *flow.State) tele.HandlerFunc {
+	//			// ...
+	//		}).Assign(func(state *flow.State) error {
+	//			username = state.Context.Message().Text
+	//			return nil
+	//		}).Ok(func(state *flow.State) error {
+	//			log.Println("username = ", username)
+	//			return nil
+	//		})
+	okFn StateHandler
+}
+
+// Validations adds validation handlers to the step.
+// Each returns a handler to execute on failure (e.g., send error message); nil on success.
+func (s *Step) Validations(fns ...ValidateHandler) *Step {
+	s.validatorsFns = append(s.validatorsFns, fns...)
+	return s
+}
+
+// Assign sets the handler to assign or process data after validation.
+func (s *Step) Assign(fn StateHandler) *Step {
+	s.assignFn = fn
+	return s
+}
+
+// Ok sets the handler called after successful assignment in this step.
+func (s *Step) Ok(fn StateHandler) *Step {
+	s.okFn = fn
+	return s
+}

--- a/flow/step_machine.go
+++ b/flow/step_machine.go
@@ -1,0 +1,118 @@
+package flow
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Machine interface {
+	// Back move backward by step.
+	Back(state *State) error
+
+	// Next move forward by step.
+	Next(state *State) error
+
+	// ToStep Move to the step.
+	ToStep(step int, state *State) error
+
+	// Ok run [Flow.okFn].
+	Ok(state *State) error
+
+	// Fail sets failed and run [Flow.errFn].
+	Fail(state *State, err error) error
+
+	// ActiveStep returns the current step.
+	ActiveStep() int
+}
+
+type machine struct {
+	flow       *Flow
+	activeStep int
+
+	failed bool
+}
+
+func (m *machine) Back(state *State) error {
+	if m.activeStep-1 <= 0 {
+		return errors.New("already first step")
+	}
+
+	m.activeStep -= 1
+
+	return m.run(state)
+}
+
+func (m *machine) Next(state *State) error {
+	if m.activeStep+1 >= len(m.flow.steps) {
+		return errors.New("already last step")
+	}
+
+	m.activeStep += 1
+
+	return m.run(state)
+}
+
+func (m *machine) ToStep(step int, state *State) error {
+	if step < 0 {
+		return errors.New("step cannot be less than zero")
+	}
+
+	if step > len(m.flow.steps) {
+		return errors.New("step cannot be greater than steps count")
+	}
+
+	m.activeStep = step
+
+	return m.run(state)
+}
+
+func (m *machine) Ok(state *State) error {
+	if m.failed {
+		return errors.New("flow was already failed")
+	}
+
+	if m.flow.okFn != nil {
+		return m.flow.okFn(state)
+	}
+
+	return nil
+}
+
+func (m *machine) Fail(state *State, err error) error {
+	m.failed = true
+
+	if m.flow.errFn != nil {
+		return m.flow.errFn(state, err)
+	}
+
+	return nil
+}
+
+func (m *machine) ActiveStep() int {
+	return m.activeStep
+}
+
+func (m *machine) run(state *State) error {
+	if m.failed {
+		return errors.New("flow was already failed")
+	}
+
+	if len(m.flow.steps) < m.activeStep {
+		return errors.New(fmt.Sprintf("step isn't defined (%d)", m.activeStep))
+	}
+
+	step := m.flow.steps[m.activeStep]
+	if step.beginFn != nil {
+		return step.beginFn(state)
+	}
+
+	return nil
+}
+
+// NewMachine constructor [Machine].
+func NewMachine(flow *Flow) Machine {
+	return &machine{
+		flow:       flow,
+		activeStep: 0,
+	}
+}

--- a/flow/storage/memory.go
+++ b/flow/storage/memory.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	ErrKeyNotFound = errors.New("key not found")
+)
+
+// Memory defines in-memory storage with use [sync.Map].
+type Memory struct {
+	data sync.Map
+}
+
+// NewMemory constructor [Memory].
+func NewMemory() Storage {
+	return &Memory{}
+}
+
+// Get gets value by key from memory storage.
+func (m *Memory) Get(key string) (interface{}, error) {
+	value, ok := m.data.Load(key)
+	if !ok {
+		return nil, ErrKeyNotFound
+	}
+	return value, nil
+}
+
+// Set sets value by key to memory storage.
+func (m *Memory) Set(_ context.Context, key string, value interface{}, _ time.Duration) error {
+	m.data.Store(key, value)
+	return nil
+}
+
+// Delete deletes value by key from memory storage.
+func (m *Memory) Delete(key string) error {
+	m.data.Delete(key)
+	return nil
+}

--- a/flow/storage/storage.go
+++ b/flow/storage/storage.go
@@ -1,0 +1,19 @@
+package storage
+
+import (
+	"context"
+	"time"
+)
+
+// Storage defines a global interface for key-value storage systems.
+// Uses in-memory storage by default.
+type Storage interface {
+	// Get gets a value by key.
+	Get(key string) (interface{}, error)
+
+	// Set sets a value by key with an expiration time.
+	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error
+
+	// Delete deletes a value by key.
+	Delete(key string) error
+}


### PR DESCRIPTION
P.S: I used #657 as a basis.

In the basic version, I did not like that Flow = tele.HandlerFunc:
```go
var email, password string
err := flowBus.Flow(
	"/start",
	flow.New().
                OnEachStep(loggingEachStep).
		Next(flow.NewStep(sendUserMessage("Enter email:")).Assign(TextAssigner(&email))).
		Next(flow.NewStep(sendUserMessage("Enter password:")).Assign(TextAssigner(&password))).
		Then(registerUser).
		Catch(flowFailed),
)
```

I would like to see the steps described inside the tele.HandlerFunc:
```go
bot.Handle("/signup", func(c tele.Context) error {
		ctx := context.Background()

		f := bus.Flow("signup", 1*time.Minute)

		var username string

		f.OnText(func(state *teleflow.State) error {
			return state.Context.EditOrSend("Enter username:")
		}).Assign(func(state *teleflow.State) error {
			username = state.Context.Message().Text
			return nil
		})

		f.OnText(func(state *teleflow.State) error {
			return state.Context.EditOrSend("Enter password:")
		}).Ok(func(state *teleflow.State) error {
			log.Println("username:", username)
			log.Println("password:", state.Context.Message().Text)

			return nil
		})

		return bus.Start(ctx, c, f)
	})
```

Why is this option better in my opinion?
In all my bots, I have a common `Handlers` structure that contains methods for registration, deposits, etc:
```go
type Handler struct {
	userService    *service.UserService
	orderService   *service.OrderService
	depositService *service.DepositService
	
	bus flow.Bus
}

func (h *Handler) SignUp() tele.HandlerFunc {
	return func(c tele.Context) error {
		// ...
	}
}

func (h *Handler) DepositByUserID() tele.HandlerFunc {
	return func(c tele.Context) error {
		// ...
	}
}
```

Therefore, I think my option is preferable, I want to thank @shindakioku for his code.