### PR TITLE
Add Bot API 9.5 sendMessageDraft

### DIFF
--- a/api.go
+++ b/api.go
@@ -77,6 +77,7 @@ type API interface {
 	Restrict(chat *Chat, member *ChatMember) error
 	RevokeInviteLink(chat Recipient, link string) (*ChatInviteLink, error)
 	Send(to Recipient, what interface{}, opts ...interface{}) (*Message, error)
+	SendMessageDraft(to Recipient, draftID int, text string, opts ...interface{}) error
 	SendAlbum(to Recipient, a Album, opts ...interface{}) ([]Message, error)
 	SendPaid(to Recipient, stars int, a PaidAlbum, opts ...interface{}) (*Message, error)
 	SetAdminTitle(chat *Chat, user *User, title string) error

--- a/bot.go
+++ b/bot.go
@@ -300,6 +300,18 @@ func (b *Bot) Send(to Recipient, what interface{}, opts ...interface{}) (*Messag
 	}
 }
 
+// SendMessageDraft streams a partial message to a user while the message is being
+// generated. Supported only for bots with forum topic mode enabled in private chats.
+// The draftID must be non-zero; changes of drafts with the same ID are animated.
+func (b *Bot) SendMessageDraft(to Recipient, draftID int, text string, opts ...interface{}) error {
+	if to == nil {
+		return ErrBadRecipient
+	}
+
+	sendOpts := b.extractOptions(opts)
+	return b.sendMessageDraft(to, draftID, text, sendOpts)
+}
+
 // SendPaid sends multiple instances of paid media as a single message.
 // To include the caption, make sure the first PaidInputtable of an album has it.
 func (b *Bot) SendPaid(to Recipient, stars int, a PaidAlbum, opts ...interface{}) (*Message, error) {

--- a/bot_raw.go
+++ b/bot_raw.go
@@ -191,6 +191,18 @@ func (b *Bot) sendText(to Recipient, text string, opt *SendOptions) (*Message, e
 	return extractMessage(data)
 }
 
+func (b *Bot) sendMessageDraft(to Recipient, draftID int, text string, opt *SendOptions) error {
+	params := map[string]string{
+		"chat_id":  to.Recipient(),
+		"draft_id": strconv.Itoa(draftID),
+		"text":     text,
+	}
+	b.embedSendOptions(params, opt)
+
+	_, err := b.Raw("sendMessageDraft", params)
+	return err
+}
+
 func (b *Bot) sendMedia(media Media, params map[string]string, files map[string]File) (*Message, error) {
 	kind := media.MediaType()
 	what := "send" + strings.Title(kind)


### PR DESCRIPTION
https://core.telegram.org/bots/api-changelog#march-1-2026

📝 Message Streaming
• With today's update, every bot on Telegram can freely use the message streaming feature.