### PR TITLE
fix: add omitempty to InlineButton.InlineQueryChat

### DIFF
--- a/markup.go
+++ b/markup.go
@@ -296,7 +296,7 @@ type InlineButton struct {
 	URL                   string             `json:"url,omitempty"`
 	Data                  string             `json:"callback_data,omitempty"`
 	InlineQuery           string             `json:"switch_inline_query,omitempty"`
-	InlineQueryChat       string             `json:"switch_inline_query_current_chat"`
+	InlineQueryChat       string             `json:"switch_inline_query_current_chat,omitempty"`
 	InlineQueryChosenChat *SwitchInlineQuery `json:"switch_inline_query_chosen_chat,omitempty"`
 	Login                 *Login             `json:"login_url,omitempty"`
 	WebApp                *WebApp            `json:"web_app,omitempty"`


### PR DESCRIPTION
Empty switch_inline_query_current_chat field was included in JSON output. Added omitempty to skip it when empty.