### PR TITLE
errors: redact bot token from wrapped transport errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package telebot
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -263,7 +264,37 @@ func ErrIs(s string, err error) bool {
 	return errors.Is(err, Err(s))
 }
 
-// wrapError returns new wrapped telebot-related error.
+// wrapError returns new wrapped telebot-related error with any bot
+// token in the underlying error's message replaced by `<token>`. The
+// stdlib http client puts the full request URL (which contains
+// `/bot<TOKEN>/<method>`) in transport errors, so without redacting
+// the token here it can end up in user logs, monitoring systems, and
+// crash reports. See #770.
 func wrapError(err error) error {
-	return fmt.Errorf("telebot: %w", err)
+	return fmt.Errorf("telebot: %w", redactToken(err))
 }
+
+var botTokenRe = regexp.MustCompile(`/bot\d+:[A-Za-z0-9_-]+`)
+
+// redactToken returns err with the bot token portion of any embedded
+// `/bot<id>:<secret>` path replaced by `/bot<token>`. The wrapped chain
+// is preserved with errors.Is / errors.As.
+func redactToken(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	redacted := botTokenRe.ReplaceAllString(msg, "/bot<token>")
+	if redacted == msg {
+		return err
+	}
+	return &redactedError{msg: redacted, wrapped: err}
+}
+
+type redactedError struct {
+	msg     string
+	wrapped error
+}
+
+func (e *redactedError) Error() string { return e.msg }
+func (e *redactedError) Unwrap() error { return e.wrapped }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,39 @@
+package telebot
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Regression for #770. The stdlib HTTP client embeds the full request
+// URL in transport errors, and that URL contains /bot<TOKEN>/<method>.
+// wrapError used to surface that token verbatim. It now redacts the
+// token before wrapping.
+func TestWrapErrorRedactsBotToken(t *testing.T) {
+	token := "123456789:AAEhBP0av28DKrJB1ULTGYojCZ0HEYJBotk"
+	rawErr := fmt.Errorf(`Post "https://api.telegram.org/bot%s/getFile": dial: timeout`, token)
+
+	wrapped := wrapError(rawErr)
+	if strings.Contains(wrapped.Error(), token) {
+		t.Fatalf("wrapped error leaked bot token: %q", wrapped.Error())
+	}
+	if !strings.Contains(wrapped.Error(), "/bot<token>") {
+		t.Fatalf("wrapped error missing /bot<token> sentinel: %q", wrapped.Error())
+	}
+	if !errors.Is(wrapped, rawErr) {
+		t.Fatal("wrapped error broke errors.Is chain to the original error")
+	}
+}
+
+func TestWrapErrorLeavesUnrelatedErrorsAlone(t *testing.T) {
+	original := errors.New("something unrelated")
+	wrapped := wrapError(original)
+	if !errors.Is(wrapped, original) {
+		t.Fatal("expected wrapped error to keep wrapping the original")
+	}
+	if want := "telebot: something unrelated"; wrapped.Error() != want {
+		t.Fatalf("wrapped error = %q, want %q", wrapped.Error(), want)
+	}
+}


### PR DESCRIPTION
Closes #770.

The Go HTTP client puts the full request URL in transport errors (timeouts, GOAWAY, RST, etc), and that URL contains \`/bot<TOKEN>/<method>\`. \`wrapError\` forwarded those errors unchanged, so a network blip dumped the bot token into user logs, alerting systems, and bug reports.

Redact \`/bot<digits>:<secret>\` to \`/bot<token>\` before wrapping, with the original error kept on \`Unwrap\` so \`errors.Is\` / \`errors.As\` keep working. Errors that don't carry a token pass through untouched.

Added \`TestWrapErrorRedactsBotToken\` and \`TestWrapErrorLeavesUnrelatedErrorsAlone\`.