### PR TITLE
fix(file): default the multipart filename to the on-disk basename

### DIFF
--- a/file.go
+++ b/file.go
@@ -3,6 +3,7 @@ package telebot
 import (
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // File object represents any sort of file.
@@ -36,7 +37,15 @@ type File struct {
 //		photo := &tele.Photo{File: tele.FromDisk("chicken.jpg")}
 //
 func FromDisk(filename string) File {
-	return File{FileLocal: filename}
+	return File{
+		FileLocal: filename,
+		// Default the multipart filename to the base name on disk so
+		// Telegram doesn't fall back to application/octet-stream and
+		// surface the upload as a generic document. Callers that
+		// explicitly set the media's FileName override this further
+		// down the pipeline.
+		fileName: filepath.Base(filename),
+	}
 }
 
 // FromURL constructs a new file on provided HTTP URL.

--- a/file_test.go
+++ b/file_test.go
@@ -13,7 +13,7 @@ func TestFile(t *testing.T) {
 
 	assert.True(t, f.OnDisk())
 	assert.True(t, (&File{FileID: "1"}).InCloud())
-	assert.Equal(t, File{FileLocal: "telebot.go"}, f)
+	assert.Equal(t, File{FileLocal: "telebot.go", fileName: "telebot.go"}, f)
 	assert.Equal(t, File{FileURL: "http://"}, g)
 	assert.Equal(t, File{FileReader: io.Reader(nil)}, FromReader(io.Reader(nil)))
 


### PR DESCRIPTION
Closes #797.

Without a \`FileName\`, the multipart \`Content-Disposition\` header has no \`filename=\` attribute. Telegram falls back to \`application/octet-stream\` and the file lands as a generic document instead of the type the caller asked for (Animation, Photo, …).

\`FromDisk\` was leaving the existing \`fileName\` field empty when it could just default it to the on-disk basename. Callers that set the media's \`FileName\` tag explicitly still win (those propagate through \`media.go\` later in the pipeline). \`TestFile\` updated to assert the new default.