### PR TITLE
feat: implement bot api 10.1 rich messages

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -592,6 +592,13 @@ func (b *Bot) Edit(msg Editable, what interface{}, opts ...interface{}) (*Messag
 	case string:
 		method = "editMessageText"
 		params["text"] = v
+	case *InputRichMessage:
+		method = "editMessageText"
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		params["rich_message"] = string(data)
 	case Location:
 		method = "editMessageLiveLocation"
 		params["latitude"] = fmt.Sprintf("%f", v.Lat)
@@ -624,6 +631,12 @@ func (b *Bot) Edit(msg Editable, what interface{}, opts ...interface{}) (*Messag
 
 	sendOpts := b.extractOptions(opts)
 	b.embedSendOptions(params, sendOpts)
+
+	// Rich content carries its own markup; text parse options never apply.
+	if _, ok := params["rich_message"]; ok {
+		delete(params, "parse_mode")
+		delete(params, "entities")
+	}
 
 	data, err := b.Raw(method, params)
 	if err != nil {

--- a/message.go
+++ b/message.go
@@ -194,6 +194,9 @@ type Message struct {
 	// Unique identifier for answering the guest query.
 	GuestQueryID string `json:"guest_query_id"`
 
+	// (Optional) For a rich message, the rich formatted content (Bot API 10.1).
+	RichMessage *RichMessage `json:"rich_message,omitempty"`
+
 	// (Optional) The bot that actually sent the message on behalf of the business account.
 	// Available only for outgoing messages sent on behalf of the connected business account.
 	BusinessBot *User `json:"sender_business_bot"`

--- a/rich.go
+++ b/rich.go
@@ -1,0 +1,118 @@
+package telebot
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// InputRichMessage describes a rich message to send with the Bot API 10.1
+// rich-message methods (sendRichMessage, sendRichMessageDraft, and the
+// rich_message parameter of editMessageText). Exactly one of HTML or Markdown
+// must be set; Telegram parses the source server-side into its rich block tree
+// — headings, tables, ordered and nested lists, blockquotes, dividers, media
+// blocks and so on — and renders it as a single message regardless of length.
+//
+// InputRichMessage implements Sendable, so the idiomatic way to send one is
+// through Send/Reply:
+//
+//	b.Send(to, &telebot.InputRichMessage{Markdown: "# Title\n\nBody"})
+//
+// and to edit a message into rich content through Edit:
+//
+//	b.Edit(msg, &telebot.InputRichMessage{HTML: "<b>done</b>"})
+type InputRichMessage struct {
+	// (Optional) Content described using Telegram's extended HTML formatting.
+	HTML string `json:"html,omitempty"`
+
+	// (Optional) Content described using Telegram's extended Markdown formatting.
+	Markdown string `json:"markdown,omitempty"`
+
+	// (Optional) Pass true to render the message right-to-left.
+	IsRTL bool `json:"is_rtl,omitempty"`
+
+	// (Optional) Pass true to skip automatic detection of URLs, email addresses,
+	// mentions, hashtags, cashtags, bot commands and phone numbers in the text.
+	SkipEntityDetection bool `json:"skip_entity_detection,omitempty"`
+}
+
+// Send delivers the rich message through bot b to recipient via the
+// sendRichMessage method, satisfying the Sendable interface.
+func (i *InputRichMessage) Send(b *Bot, to Recipient, opt *SendOptions) (*Message, error) {
+	data, err := json.Marshal(i)
+	if err != nil {
+		return nil, err
+	}
+
+	params := map[string]string{
+		"chat_id":      to.Recipient(),
+		"rich_message": string(data),
+	}
+	b.embedSendOptions(params, opt)
+
+	// Parse mode and entities apply to plain text, never to rich content; the
+	// markup is carried inside the InputRichMessage itself.
+	delete(params, "parse_mode")
+	delete(params, "entities")
+
+	raw, err := b.Raw("sendRichMessage", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractMessage(raw)
+}
+
+// SendRichDraft streams a partial rich message to a private chat while it is
+// being generated (the sendRichMessageDraft method). The streamed draft is
+// ephemeral and acts as a temporary 30-second preview; once the output is
+// finalized you must Send the complete InputRichMessage to persist it. draftID
+// must be non-zero — updates sharing the same identifier are animated
+// client-side. Of the send options only ThreadID is honored.
+func (b *Bot) SendRichDraft(to Recipient, draftID int, rich *InputRichMessage, opts ...interface{}) error {
+	if to == nil {
+		return ErrBadRecipient
+	}
+	if rich == nil {
+		return ErrUnsupportedWhat
+	}
+
+	data, err := json.Marshal(rich)
+	if err != nil {
+		return err
+	}
+
+	params := map[string]string{
+		"chat_id":      to.Recipient(),
+		"draft_id":     strconv.Itoa(draftID),
+		"rich_message": string(data),
+	}
+
+	if sendOpts := b.extractOptions(opts); sendOpts != nil && sendOpts.ThreadID != 0 {
+		params["message_thread_id"] = strconv.Itoa(sendOpts.ThreadID)
+	}
+
+	_, err = b.Raw("sendRichMessageDraft", params)
+	return err
+}
+
+// InputRichMessageContent represents the content of a rich message to be sent
+// as the result of an inline, guest or Web App query (Bot API 10.1).
+type InputRichMessageContent struct {
+	// The rich message to be sent.
+	RichMessage *InputRichMessage `json:"rich_message"`
+}
+
+// IsInputMessageContent marks InputRichMessageContent as InputMessageContent.
+func (i *InputRichMessageContent) IsInputMessageContent() bool {
+	return true
+}
+
+// RichMessage represents a received rich formatted message (Bot API 10.1),
+// available on Message.RichMessage. Its content is a tree of RichBlock values.
+type RichMessage struct {
+	// Content of the message, as an ordered list of blocks.
+	Blocks []RichBlock `json:"blocks"`
+
+	// (Optional) True if the message must be shown right-to-left.
+	IsRTL bool `json:"is_rtl,omitempty"`
+}

--- a/rich_block.go
+++ b/rich_block.go
@@ -1,0 +1,165 @@
+package telebot
+
+import "encoding/json"
+
+// RichBlock type discriminators, as carried in the "type" field of a received
+// rich block (Bot API 10.1).
+const (
+	RichBlockParagraph     = "paragraph"
+	RichBlockHeading       = "heading"
+	RichBlockPre           = "pre"
+	RichBlockFooter        = "footer"
+	RichBlockDivider       = "divider"
+	RichBlockMath          = "mathematical_expression"
+	RichBlockAnchor        = "anchor"
+	RichBlockList          = "list"
+	RichBlockBlockquote    = "blockquote"
+	RichBlockPullquote     = "pullquote"
+	RichBlockCollage       = "collage"
+	RichBlockSlideshow     = "slideshow"
+	RichBlockTable         = "table"
+	RichBlockDetails       = "details"
+	RichBlockMap           = "map"
+	RichBlockAnimationType = "animation"
+	RichBlockAudioType     = "audio"
+	RichBlockPhotoType     = "photo"
+	RichBlockVideoType     = "video"
+	RichBlockVoiceNote     = "voice_note"
+	RichBlockThinking      = "thinking"
+)
+
+// RichBlock is a single block of a received RichMessage (Bot API 10.1). It is a
+// polymorphic type discriminated by Type; only the fields relevant to a given
+// Type are populated. RichBlock is a received-only type.
+type RichBlock struct {
+	// Type is the block discriminator (see the RichBlock* constants).
+	Type string `json:"type"`
+
+	// Text is the block's formatted text (paragraph, heading, pre, footer,
+	// pullquote, thinking).
+	Text *RichText `json:"text,omitempty"`
+
+	// Size is the heading level, 1 (largest) to 6 (smallest).
+	Size int `json:"size,omitempty"`
+
+	// Language is the optional source language of a "pre" block.
+	Language string `json:"language,omitempty"`
+
+	// Expression is the LaTeX of a "mathematical_expression" block.
+	Expression string `json:"expression,omitempty"`
+
+	// Name is the identifier of an "anchor" block.
+	Name string `json:"name,omitempty"`
+
+	// Items are the entries of a "list" block.
+	Items []RichBlockListItem `json:"items,omitempty"`
+
+	// Blocks are the nested blocks of a blockquote, collage, slideshow or
+	// details block.
+	Blocks []RichBlock `json:"blocks,omitempty"`
+
+	// Summary is the disclosure summary of a "details" block.
+	Summary *RichText `json:"summary,omitempty"`
+
+	// IsOpen reports whether a "details" block is expanded by default.
+	IsOpen bool `json:"is_open,omitempty"`
+
+	// Credit is the attribution of a blockquote or pullquote block.
+	Credit *RichText `json:"credit,omitempty"`
+
+	// Cells are the rows-by-columns of a "table" block.
+	Cells [][]RichBlockTableCell `json:"cells,omitempty"`
+
+	// IsBordered and IsStriped style a "table" block.
+	IsBordered bool `json:"is_bordered,omitempty"`
+	IsStriped  bool `json:"is_striped,omitempty"`
+
+	// Location, Zoom, Width and Height describe a "map" block.
+	Location *Location `json:"location,omitempty"`
+	Zoom     int       `json:"zoom,omitempty"`
+	Width    int       `json:"width,omitempty"`
+	Height   int       `json:"height,omitempty"`
+
+	// Media of the corresponding block type.
+	Animation *Animation `json:"animation,omitempty"`
+	Audio     *Audio     `json:"audio,omitempty"`
+	Photo     []Photo    `json:"photo,omitempty"`
+	Video     *Video     `json:"video,omitempty"`
+	VoiceNote *Voice     `json:"voice_note,omitempty"`
+
+	// HasSpoiler marks an animation, photo or video block as a spoiler.
+	HasSpoiler bool `json:"has_spoiler,omitempty"`
+
+	// Caption is the caption of a collage, slideshow, map, animation, audio,
+	// photo, video or voice-note block.
+	Caption *RichBlockCaption `json:"-"`
+
+	// TableCaption is the caption of a "table" block (a bare RichText rather
+	// than a RichBlockCaption).
+	TableCaption *RichText `json:"-"`
+}
+
+// UnmarshalJSON decodes a RichBlock, resolving the polymorphic "caption" field:
+// a table carries a bare RichText caption, every other block a RichBlockCaption.
+func (rb *RichBlock) UnmarshalJSON(data []byte) error {
+	type alias RichBlock
+	aux := struct {
+		*alias
+		Caption json.RawMessage `json:"caption,omitempty"`
+	}{alias: (*alias)(rb)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if len(aux.Caption) == 0 || string(aux.Caption) == "null" {
+		return nil
+	}
+
+	if rb.Type == RichBlockTable {
+		rb.TableCaption = new(RichText)
+		return json.Unmarshal(aux.Caption, rb.TableCaption)
+	}
+
+	rb.Caption = new(RichBlockCaption)
+	return json.Unmarshal(aux.Caption, rb.Caption)
+}
+
+// RichBlockCaption is the caption of a media or container rich block.
+type RichBlockCaption struct {
+	// Text of the caption.
+	Text RichText `json:"text"`
+
+	// (Optional) Attribution shown alongside the caption.
+	Credit *RichText `json:"credit,omitempty"`
+}
+
+// RichBlockTableCell is a single cell of a "table" rich block. An omitted Text
+// denotes an invisible cell spanned into by a neighbour.
+type RichBlockTableCell struct {
+	Text     *RichText `json:"text,omitempty"`
+	IsHeader bool      `json:"is_header,omitempty"`
+	Colspan  int       `json:"colspan,omitempty"`
+	Rowspan  int       `json:"rowspan,omitempty"`
+	Align    string    `json:"align,omitempty"`  // "left", "center", "right"
+	VAlign   string    `json:"valign,omitempty"` // "top", "middle", "bottom"
+}
+
+// RichBlockListItem is a single entry of a "list" rich block.
+type RichBlockListItem struct {
+	// Label is the rendered bullet or number of the item.
+	Label string `json:"label,omitempty"`
+
+	// Blocks is the content of the item.
+	Blocks []RichBlock `json:"blocks,omitempty"`
+
+	// HasCheckbox and IsChecked render a task-list item.
+	HasCheckbox bool `json:"has_checkbox,omitempty"`
+	IsChecked   bool `json:"is_checked,omitempty"`
+
+	// Value is the ordinal of an ordered-list item.
+	Value int `json:"value,omitempty"`
+
+	// Type is the label style of an ordered item ("a", "A", "i", "I", "1").
+	Type string `json:"type,omitempty"`
+}

--- a/rich_test.go
+++ b/rich_test.go
@@ -1,0 +1,178 @@
+package telebot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// richBot returns an offline bot whose requests hit srv and records the decoded
+// request path and JSON body for assertions.
+func richBot(t *testing.T, result string, path *string, body *map[string]interface{}) *Bot {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*path = r.URL.Path
+		require.NoError(t, json.NewDecoder(r.Body).Decode(body))
+		w.Write([]byte(result))
+	}))
+	t.Cleanup(srv.Close)
+
+	b, err := NewBot(Settings{
+		Offline:   true,
+		Token:     "token",
+		URL:       srv.URL,
+		Client:    srv.Client(),
+		ParseMode: ModeHTML, // proves parse_mode is never leaked onto rich calls
+	})
+	require.NoError(t, err)
+	return b
+}
+
+func TestSendRich(t *testing.T) {
+	var path string
+	var body map[string]interface{}
+	b := richBot(t, `{"ok":true,"result":{"message_id":42,"chat":{"id":2,"type":"private"}}}`, &path, &body)
+
+	msg, err := b.Send(ChatID(2), &InputRichMessage{
+		Markdown:            "# Title\n\n- a\n- b",
+		IsRTL:               true,
+		SkipEntityDetection: true,
+	}, Silent)
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+
+	assert.Equal(t, "/bottoken/sendRichMessage", path)
+	assert.Equal(t, 42, msg.ID)
+	assert.Equal(t, "2", body["chat_id"])
+	assert.Equal(t, "true", body["disable_notification"])
+	assert.NotContains(t, body, "parse_mode")
+
+	// Object params ride as JSON-encoded strings, as with reply_markup/media.
+	var rich map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(body["rich_message"].(string)), &rich))
+	assert.Equal(t, "# Title\n\n- a\n- b", rich["markdown"])
+	assert.Equal(t, true, rich["is_rtl"])
+	assert.Equal(t, true, rich["skip_entity_detection"])
+	assert.NotContains(t, rich, "html")
+}
+
+func TestEditRich(t *testing.T) {
+	var path string
+	var body map[string]interface{}
+	b := richBot(t, `{"ok":true,"result":{"message_id":7,"chat":{"id":2,"type":"private"}}}`, &path, &body)
+
+	_, err := b.Edit(&Message{ID: 7, Chat: &Chat{ID: 2}}, &InputRichMessage{HTML: "<b>done</b>"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/bottoken/editMessageText", path)
+	assert.Equal(t, "7", body["message_id"])
+	assert.Equal(t, "2", body["chat_id"])
+	assert.NotContains(t, body, "text")
+	assert.NotContains(t, body, "parse_mode")
+
+	var rich map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(body["rich_message"].(string)), &rich))
+	assert.Equal(t, "<b>done</b>", rich["html"])
+}
+
+func TestSendRichDraft(t *testing.T) {
+	var path string
+	var body map[string]interface{}
+	b := richBot(t, `{"ok":true,"result":true}`, &path, &body)
+
+	err := b.SendRichDraft(ChatID(2), 99, &InputRichMessage{Markdown: "thinking…"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/bottoken/sendRichMessageDraft", path)
+	assert.Equal(t, "99", body["draft_id"])
+	assert.Equal(t, "2", body["chat_id"])
+	assert.Contains(t, body, "rich_message")
+}
+
+func TestRichBadInput(t *testing.T) {
+	b, err := NewBot(Settings{Offline: true, Token: "token"})
+	require.NoError(t, err)
+
+	_, err = b.Send(nil, &InputRichMessage{Markdown: "x"})
+	assert.ErrorIs(t, err, ErrBadRecipient)
+
+	assert.ErrorIs(t, b.SendRichDraft(nil, 1, &InputRichMessage{Markdown: "x"}), ErrBadRecipient)
+	assert.ErrorIs(t, b.SendRichDraft(ChatID(2), 1, nil), ErrUnsupportedWhat)
+}
+
+func TestInputRichMessageContent(t *testing.T) {
+	var _ InputMessageContent = (*InputRichMessageContent)(nil)
+
+	data, err := json.Marshal(&InputRichMessageContent{
+		RichMessage: &InputRichMessage{Markdown: "hi"},
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"rich_message":{"markdown":"hi"}}`, string(data))
+}
+
+func TestRichMessageUnmarshal(t *testing.T) {
+	data := []byte(`{
+		"message_id": 7,
+		"chat": {"id": 2, "type": "private"},
+		"rich_message": {
+			"is_rtl": false,
+			"blocks": [
+				{"type": "heading", "text": "Quarterly Report", "size": 1},
+				{"type": "paragraph", "text": ["Revenue is ", {"type": "bold", "text": "up 20%"}, "."]},
+				{"type": "list", "items": [
+					{"label": "1", "blocks": [{"type": "paragraph", "text": "First"}], "has_checkbox": true, "is_checked": true}
+				]},
+				{"type": "table", "is_bordered": true, "caption": "Results", "cells": [
+					[{"text": "Q1", "is_header": true}, {"text": "Q2", "is_header": true}],
+					[{"text": "100"}, {"text": "120"}]
+				]},
+				{"type": "photo", "photo": [{"file_id": "abc", "width": 100, "height": 100}], "caption": {"text": "A chart", "credit": "Acme"}}
+			]
+		}
+	}`)
+
+	var msg Message
+	require.NoError(t, json.Unmarshal(data, &msg))
+	require.NotNil(t, msg.RichMessage)
+	rm := msg.RichMessage
+	require.Len(t, rm.Blocks, 5)
+
+	// heading: tagged-string text
+	assert.Equal(t, RichBlockHeading, rm.Blocks[0].Type)
+	assert.Equal(t, 1, rm.Blocks[0].Size)
+	assert.Equal(t, "Quarterly Report", rm.Blocks[0].Text.String())
+
+	// paragraph: array text mixing plain and a bold entity
+	para := rm.Blocks[1].Text
+	require.Equal(t, RichTextArray, para.Kind)
+	assert.Equal(t, "Revenue is up 20%.", para.String())
+
+	// list: task item
+	require.Len(t, rm.Blocks[2].Items, 1)
+	item := rm.Blocks[2].Items[0]
+	assert.True(t, item.HasCheckbox)
+	assert.True(t, item.IsChecked)
+	assert.Equal(t, "First", item.Blocks[0].Text.String())
+
+	// table: bare-RichText caption + header cells
+	tbl := rm.Blocks[3]
+	assert.True(t, tbl.IsBordered)
+	require.NotNil(t, tbl.TableCaption)
+	assert.Equal(t, "Results", tbl.TableCaption.String())
+	assert.Nil(t, tbl.Caption)
+	require.Len(t, tbl.Cells, 2)
+	assert.True(t, tbl.Cells[0][0].IsHeader)
+	assert.Equal(t, "Q1", tbl.Cells[0][0].Text.String())
+
+	// photo: RichBlockCaption caption + media
+	photo := rm.Blocks[4]
+	require.Len(t, photo.Photo, 1)
+	require.NotNil(t, photo.Caption)
+	assert.Equal(t, "A chart", photo.Caption.Text.String())
+	require.NotNil(t, photo.Caption.Credit)
+	assert.Equal(t, "Acme", photo.Caption.Credit.String())
+}

--- a/rich_text.go
+++ b/rich_text.go
@@ -1,0 +1,180 @@
+package telebot
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// RichTextKind tells which of the three wire forms a RichText holds.
+type RichTextKind int
+
+const (
+	// RichTextPlain is a bare string of plain text.
+	RichTextPlain RichTextKind = iota
+
+	// RichTextArray is an ordered run of RichText values (mixed formatting).
+	RichTextArray
+
+	// RichTextEntity is a single tagged formatting entity (see RichText.Type).
+	RichTextEntity
+)
+
+// RichText type discriminators, as carried in the "type" field of a tagged
+// RichText entity (Bot API 10.1).
+const (
+	RichBold                   = "bold"
+	RichItalic                 = "italic"
+	RichUnderline              = "underline"
+	RichStrikethrough          = "strikethrough"
+	RichSpoiler                = "spoiler"
+	RichDateTime               = "date_time"
+	RichTextMentionType        = "text_mention"
+	RichSubscript              = "subscript"
+	RichSuperscript            = "superscript"
+	RichMarked                 = "marked"
+	RichCode                   = "code"
+	RichCustomEmoji            = "custom_emoji"
+	RichMathematicalExpression = "mathematical_expression"
+	RichURL                    = "url"
+	RichEmailAddress           = "email_address"
+	RichPhoneNumber            = "phone_number"
+	RichBankCardNumber         = "bank_card_number"
+	RichMention                = "mention"
+	RichHashtag                = "hashtag"
+	RichCashtag                = "cashtag"
+	RichBotCommand             = "bot_command"
+	RichAnchor                 = "anchor"
+	RichAnchorLink             = "anchor_link"
+	RichReference              = "reference"
+	RichReferenceLink          = "reference_link"
+)
+
+// RichText is a polymorphic piece of rich-formatted text (Bot API 10.1). On the
+// wire it is one of: a plain string, an array of RichText, or a tagged object
+// carrying a "type" discriminator and a (usually nested) text. Kind reports
+// which form was decoded; the relevant fields are populated accordingly.
+//
+// RichText is a received-only type — rich content is sent as HTML or Markdown
+// via InputRichMessage, never as a block tree.
+type RichText struct {
+	// Kind is the wire form this value was decoded from.
+	Kind RichTextKind `json:"-"`
+
+	// Plain holds the text when Kind is RichTextPlain.
+	Plain string `json:"-"`
+
+	// Parts holds the run when Kind is RichTextArray.
+	Parts []RichText `json:"-"`
+
+	// Type is the entity discriminator when Kind is RichTextEntity.
+	Type string `json:"type,omitempty"`
+
+	// Text is the nested, formatted text of the entity (most entity types).
+	Text *RichText `json:"text,omitempty"`
+
+	// URL is the target of a "url" entity.
+	URL string `json:"url,omitempty"`
+
+	// EmailAddress is the address of an "email_address" entity.
+	EmailAddress string `json:"email_address,omitempty"`
+
+	// PhoneNumber is the number of a "phone_number" entity.
+	PhoneNumber string `json:"phone_number,omitempty"`
+
+	// BankCardNumber is the number of a "bank_card_number" entity.
+	BankCardNumber string `json:"bank_card_number,omitempty"`
+
+	// Username is the @username of a "mention" entity.
+	Username string `json:"username,omitempty"`
+
+	// Hashtag is the tag of a "hashtag" entity.
+	Hashtag string `json:"hashtag,omitempty"`
+
+	// Cashtag is the tag of a "cashtag" entity.
+	Cashtag string `json:"cashtag,omitempty"`
+
+	// BotCommand is the command of a "bot_command" entity.
+	BotCommand string `json:"bot_command,omitempty"`
+
+	// User is the mentioned user of a "text_mention" entity.
+	User *User `json:"user,omitempty"`
+
+	// UnixTime is the moment of a "date_time" entity, in Unix time.
+	UnixTime int64 `json:"unix_time,omitempty"`
+
+	// DateTimeFormat is the rendering format of a "date_time" entity.
+	DateTimeFormat string `json:"date_time_format,omitempty"`
+
+	// CustomEmojiID is the identifier of a "custom_emoji" entity.
+	CustomEmojiID string `json:"custom_emoji_id,omitempty"`
+
+	// AlternativeText is the fallback text of a "custom_emoji" entity.
+	AlternativeText string `json:"alternative_text,omitempty"`
+
+	// Expression is the LaTeX of a "mathematical_expression" entity.
+	Expression string `json:"expression,omitempty"`
+
+	// Name is the identifier of an "anchor" or "reference" entity.
+	Name string `json:"name,omitempty"`
+
+	// AnchorName is the target of an "anchor_link" entity (empty = top).
+	AnchorName string `json:"anchor_name,omitempty"`
+
+	// ReferenceName is the target of a "reference_link" entity.
+	ReferenceName string `json:"reference_name,omitempty"`
+}
+
+// UnmarshalJSON decodes the string, array and tagged-object forms of RichText.
+func (r *RichText) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+
+	switch data[0] {
+	case '"':
+		r.Kind = RichTextPlain
+		return json.Unmarshal(data, &r.Plain)
+	case '[':
+		r.Kind = RichTextArray
+		return json.Unmarshal(data, &r.Parts)
+	case '{':
+		r.Kind = RichTextEntity
+		type alias RichText
+		return json.Unmarshal(data, (*alias)(r))
+	default:
+		return wrapError(fmt.Errorf("telebot: invalid RichText value: %s", data))
+	}
+}
+
+// String renders the RichText as plain text, recursively flattening arrays and
+// entities. Entities without textual content (anchors, dividers) contribute
+// nothing; custom emoji contribute their alternative text.
+func (r RichText) String() string {
+	switch r.Kind {
+	case RichTextPlain:
+		return r.Plain
+	case RichTextArray:
+		var b strings.Builder
+		for i := range r.Parts {
+			b.WriteString(r.Parts[i].String())
+		}
+		return b.String()
+	default: // RichTextEntity
+		switch r.Type {
+		case RichCustomEmoji:
+			return r.AlternativeText
+		case RichMathematicalExpression:
+			return r.Expression
+		case RichAnchor:
+			return ""
+		default:
+			if r.Text != nil {
+				return r.Text.String()
+			}
+			return ""
+		}
+	}
+}


### PR DESCRIPTION
## What

Implements **Bot API 10.1 — Rich Messages** ([changelog, June 11 2026](https://core.telegram.org/bots/api-changelog#june-11-2026)): the `sendRichMessage`, `sendRichMessageDraft` and `editMessageText` rich paths, the `InputRichMessage` / `InputRichMessageContent` input types, and the full received `RichMessage` → `RichBlock` / `RichText` tree.

## API surface

Sending is idiomatic — `InputRichMessage` implements `Sendable`, so it flows through the existing `Send`/`Reply`/`Edit`, no bespoke `SendRich`:

```go
// send (sendRichMessage)
b.Send(to, &telebot.InputRichMessage{Markdown: "# Report\n\n| A | B |\n|---|---|\n| 1 | 2 |"})

// edit a message into rich content (editMessageText rich_message)
b.Edit(msg, &telebot.InputRichMessage{HTML: "<b>updated</b>"})

// stream a partial draft (sendRichMessageDraft)
b.SendRichDraft(to, draftID, &telebot.InputRichMessage{Markdown: partial})
```

New exported symbols:

- `InputRichMessage{ HTML, Markdown string; IsRTL, SkipEntityDetection bool }` — implements `Sendable`.
- `Bot.SendRichDraft(to, draftID, *InputRichMessage, ...opts) error` — mirrors the existing `SendDraft`.
- `InputRichMessageContent{ RichMessage *InputRichMessage }` — implements `InputMessageContent` (inline / guest / Web App results).
- `Message.RichMessage *RichMessage`; `RichMessage{ Blocks []RichBlock; IsRTL bool }`.
- `RichBlock` (21 block variants + helpers `RichBlockCaption`, `RichBlockTableCell`, `RichBlockListItem`).
- `RichText` (24 entity variants) with `String()` to flatten to plain text.
- `Bot.Edit` gains a `case *InputRichMessage`.

## Design notes

- **Input is `html` XOR `markdown` (+ `is_rtl`, `skip_entity_detection`)** — per the spec the bot authors Telegram's extended HTML/Markdown and the server parses it into blocks. The structured block tree only ever appears on the **received** side, so `RichText`/`RichBlock` are decode-only.
- **Received unions follow the existing flat-struct convention** (`PaidMedia`, `MessageOrigin`): `RichBlock` is one struct keyed by `Type`, reusing `Animation`/`Audio`/`Video`/`Voice`/`Photo`/`Location`/`User`.
- **`RichText` needs a custom `UnmarshalJSON`** — its wire form is genuinely polymorphic (bare string · array of `RichText` · tagged object). The single spot where a flat struct can't express the schema (a `table`'s `caption` is a bare `RichText`, every other block's is a `RichBlockCaption`) is handled by one contained unmarshal hook on `RichBlock`.
- Parse-mode/entities are stripped on the rich send and edit paths — they only apply to plain text.

## Tests

Offline tests (`rich_test.go`) cover send, edit, draft, bad-input, `InputMessageContent` marshaling, and a full received-tree decode (heading + mixed-run paragraph + task-list + bordered table-with-caption + photo-with-caption, exercising all three `RichText` forms and both caption paths). Full offline suite is green; `go vet` and `gofmt` clean. No changes to existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
