### PR TITLE
chore: migrate io/ioutil to io and os

### DIFF
--- a/bot_raw.go
+++ b/bot_raw.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -58,7 +57,7 @@ func (b *Bot) Raw(method string, payload interface{}) ([]byte, error) {
 	resp.Close = true
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, wrapError(err)
 	}
@@ -131,7 +130,7 @@ func (b *Bot) sendFiles(method string, files map[string]File, params map[string]
 		return nil, ErrInternal
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, wrapError(err)
 	}

--- a/bot_test.go
+++ b/bot_test.go
@@ -3,7 +3,6 @@ package telebot
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -611,7 +610,7 @@ func TestBot(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		file, err := ioutil.TempFile("", "")
+		file, err := os.CreateTemp("", "")
 		require.NoError(t, err)
 
 		_, err = io.Copy(file, resp.Body)

--- a/layout/parser.go
+++ b/layout/parser.go
@@ -2,7 +2,6 @@ package layout
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -241,7 +240,7 @@ func (lt *Layout) parseLocales(dir string) error {
 			return nil
 		}
 
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`io/ioutil` has been deprecated since Go 1.16. `bot_raw.go` still read response bodies through it, and two more call sites were left elsewhere in the tree:

- `bot_raw.go` — `ioutil.ReadAll` → `io.ReadAll` (2 sites)
- `layout/parser.go` — `ioutil.ReadFile` → `os.ReadFile`
- `bot_test.go` — `ioutil.TempFile` → `os.CreateTemp`

No behaviour change. `go build`, `go vet` and the full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)