### PR TITLE
feat: derive bot ID from token in offline mode

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -53,7 +53,18 @@ func NewBot(pref Settings) (*Bot, error) {
 	}
 
 	if pref.Offline {
-		bot.Me = &User{}
+		// Derive the bot ID from the token so that offline tests can rely on
+		// b.Me.ID (e.g. UserJoined checks). Left as 0 for malformed tokens.
+		var botID int64
+		if pos := strings.IndexByte(bot.Token, ':'); pos > 0 {
+			v, err := strconv.ParseInt(bot.Token[:pos], 10, 64)
+			if err != nil || v <= 0 {
+				bot.debug(fmt.Errorf("cannot derive bot ID from token: %q", bot.Token[:pos]))
+			} else {
+				botID = v
+			}
+		}
+		bot.Me = &User{ID: botID}
 	} else {
 		user, err := bot.getMe()
 		if err != nil {


### PR DESCRIPTION
`Offline: true` leaves `Bot.Me` empty, so any logic that compares against `b.Me.ID` cannot be exercised in tests. `ProcessContext` does exactly that when deciding whether the bot itself was added to a group:

```go
wasAdded := (m.UserJoined != nil && m.UserJoined.ID == b.Me.ID) ||
    (m.UsersJoined != nil && isUserInList(b.Me, m.UsersJoined))
```

With an empty `Me` this always compares against 0, so `OnAddedToGroup` is untestable offline.

The bot ID is already the part of the token before the colon, so it is parsed from there. Non-positive and overflowing values are rejected rather than silently collapsing into a bogus ID, and a malformed token is reported through `debug`.

```
token="123456:AAA"               -> Me.ID=123456
token="" / "BAD" / "abc:AAA"     -> Me.ID=0
token="-1:AAA"                   -> Me.ID=0
token="99999999999999999999:AAA" -> Me.ID=0
```

Online behaviour is untouched. `go build`, `go vet` and the full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)