### PR TITLE
feat: route slash-prefixed callback uniques to command handlers

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -154,7 +154,7 @@ func (b *Bot) Use(middleware ...MiddlewareFunc) {
 
 var (
 	cmdRx   = regexp.MustCompile(`^(/\w+)(@(\w+))?(\s|$)(.+)?`)
-	cbackRx = regexp.MustCompile(`^\f([-\w]+)(\|(.+))?$`)
+	cbackRx = regexp.MustCompile(`^\f([-\w/]+)(\|(.+))?$`)
 )
 
 // Handle lets you set the handler for some command name or

--- a/callback_route_test.go
+++ b/callback_route_test.go
@@ -1,0 +1,48 @@
+package telebot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Buttons built with a slash-prefixed unique (e.g. menu.Data(text, "/setting/lang", ...))
+// must reach the command handler registered under the same path, while plain
+// uniques keep going through the "\f"-namespaced lookup.
+func TestCallbackRouting(t *testing.T) {
+	b, err := NewBot(Settings{Token: "1:offline", Offline: true, Synchronous: true})
+	assert.NoError(t, err)
+
+	var (
+		args     []string
+		sender   int64
+		callback bool
+		plain    bool
+	)
+
+	b.Handle("/setting/lang", func(c Context) error {
+		args, sender, callback = c.Args(), c.Sender().ID, c.Callback() != nil
+		return nil
+	})
+	b.Handle("\fplain", func(c Context) error {
+		plain = true
+		return nil
+	})
+
+	b.ProcessUpdate(Update{Callback: &Callback{
+		Sender:  &User{ID: 555},
+		Message: &Message{Chat: &Chat{ID: 9}, Sender: &User{ID: 42}},
+		Data:    "\f/setting/lang|100|zh|save",
+	}})
+
+	assert.Equal(t, []string{"100", "zh", "save"}, args)
+	assert.Equal(t, int64(555), sender, "sender must be the clicking user, not the bot")
+	assert.True(t, callback, "handler must be able to tell it was invoked by a callback")
+
+	b.ProcessUpdate(Update{Callback: &Callback{
+		Sender:  &User{ID: 555},
+		Message: &Message{Chat: &Chat{ID: 9}},
+		Data:    "\fplain|x",
+	}})
+	assert.True(t, plain, "plain uniques must keep working")
+}

--- a/update.go
+++ b/update.go
@@ -286,9 +286,20 @@ func (b *Bot) ProcessContext(c Context) {
 			match := cbackRx.FindAllStringSubmatch(data, -1)
 			if match != nil {
 				unique, payload := match[0][1], match[0][3]
-				if handler, ok := b.handlers["\f"+unique]; ok {
+				// A slash-prefixed unique addresses a command handler directly,
+				// which lets buttons and commands share one handler.
+				endpoint := "\f" + unique
+				if len(unique) > 1 && unique[0] == '/' {
+					endpoint = unique
+				}
+				if handler, ok := b.handlers[endpoint]; ok {
 					u.Callback.Unique = unique
 					u.Callback.Data = payload
+					// Command handlers have no reason to call Respond, so the
+					// client would spin until the callback times out.
+					if endpoint == unique {
+						handler = withAutoRespond(handler)
+					}
 					b.runHandler(handler, c)
 					return
 				}
@@ -416,6 +427,17 @@ func (b *Bot) handleMedia(c Context) bool {
 	}
 
 	return true
+}
+
+// withAutoRespond acknowledges the callback after the handler is done,
+// so the client stops showing the loading indicator. Errors are ignored:
+// the handler may have already responded itself.
+func withAutoRespond(h HandlerFunc) HandlerFunc {
+	return func(c Context) error {
+		err := h(c)
+		_ = c.Respond()
+		return err
+	}
 }
 
 func (b *Bot) runHandler(h HandlerFunc, c Context) {


### PR DESCRIPTION
A command and the inline buttons that lead back into it usually want the same handler. Today they cannot share one: `Handle("/setting")` registers under `/setting`, while a button's unique is looked up under `\\f<unique>`, so the handler has to be registered twice.

This allows `/` inside a callback unique and dispatches a slash-prefixed one to the command handler of the same name:

```go
b.Handle("/setting/lang", onSettingLang)

// the same handler, reached from a button:
menu.Data("🏁 Language", "/setting/lang", botID, code)
```

Plain uniques keep going through the `\\f`-namespaced lookup, unchanged.

Command handlers have no reason to call `Respond`, and without it the client spins until the callback times out, so the acknowledgement is sent automatically once such a handler returns. Its error is ignored — the handler may well have responded itself.

The context stays a genuine callback context, which the added test pins down: `Args` splits on `|`, `Sender` is the user who clicked rather than the bot, and `Callback()` is non-nil so a shared handler can tell the two entry points apart.

`go build`, `go vet` and the full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)