### PR TITLE
Add Bot API 10.2 + 10.3 support

### DIFF
--- a/api.go
+++ b/api.go
@@ -84,7 +84,8 @@ type API interface {
 	RevokeInviteLink(chat Recipient, link string) (*ChatInviteLink, error)
 	Send(to Recipient, what interface{}, opts ...interface{}) (*Message, error)
 	SendAlbum(to Recipient, a Album, opts ...interface{}) ([]Message, error)
-	SendDraft(to Recipient, draftID int, text string, opts ...interface{}) error
+	SendDraft(to Recipient, draftID int64, text string, opts ...interface{}) error
+	SendRichDraft(to Recipient, draftID int64, rich *InputRichMessage, opts ...interface{}) error
 	SendPaidMedia(to Recipient, stars int, a PaidAlbum, opts ...interface{}) (*Message, error)
 	SendGift(to Recipient, giftID string, opts ...interface{}) error
 	SavePreparedInlineMessage(user Recipient, result Result, opts ...interface{}) (*PreparedInlineMessage, error)

--- a/bot.go
+++ b/bot.go
@@ -308,7 +308,7 @@ func (b *Bot) Send(to Recipient, what interface{}, opts ...interface{}) (*Messag
 //
 // Only ParseMode, Entities and ThreadID send options are honored; other fields
 // are not accepted by sendMessageDraft.
-func (b *Bot) SendDraft(to Recipient, draftID int, text string, opts ...interface{}) error {
+func (b *Bot) SendDraft(to Recipient, draftID int64, text string, opts ...interface{}) error {
 	if to == nil {
 		return ErrBadRecipient
 	}
@@ -317,13 +317,19 @@ func (b *Bot) SendDraft(to Recipient, draftID int, text string, opts ...interfac
 
 	params := map[string]string{
 		"chat_id":  to.Recipient(),
-		"draft_id": strconv.Itoa(draftID),
+		"draft_id": strconv.FormatInt(draftID, 10),
 		"text":     text,
 	}
 
 	if sendOpts != nil {
 		if sendOpts.ThreadID != 0 {
 			params["message_thread_id"] = strconv.Itoa(sendOpts.ThreadID)
+		}
+		if sendOpts.CanStop {
+			params["can_stop"] = "true"
+		}
+		if sendOpts.KeepOnStop {
+			params["keep_on_stop"] = "true"
 		}
 		if len(sendOpts.Entities) > 0 {
 			entities, _ := json.Marshal(sendOpts.Entities)

--- a/context.go
+++ b/context.go
@@ -76,6 +76,9 @@ type Context interface {
 	// PurchasedPaidMedia returns the purchased paid media instance.
 	PurchasedPaidMedia() *PaidMediaPurchased
 
+	// GenerationStopped returns the generation stopped event if such presented.
+	GenerationStopped() *MessageGenerationStopped
+
 	// Sender returns the current recipient, depending on the context type.
 	// Returns nil if user is not presented.
 	Sender() *User
@@ -315,6 +318,10 @@ func (c *nativeContext) BoostRemoved() *BoostRemoved {
 
 func (c *nativeContext) PurchasedPaidMedia() *PaidMediaPurchased {
 	return c.u.PurchasedPaidMedia
+}
+
+func (c *nativeContext) GenerationStopped() *MessageGenerationStopped {
+	return c.u.StoppedMessageGeneration
 }
 
 func (c *nativeContext) Sender() *User {

--- a/go.sum
+++ b/go.sum
@@ -127,7 +127,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=

--- a/input_rich_block.go
+++ b/input_rich_block.go
@@ -1,0 +1,192 @@
+package telebot
+
+// InputRichBlock is the interface for all block types that can appear in
+// InputRichMessage.Blocks (Bot API 10.2).
+type InputRichBlock interface {
+	inputRichBlock()
+}
+
+// InputRichBlockParagraph is a paragraph block.
+type InputRichBlockParagraph struct {
+	Type string   `json:"type"`
+	Text RichText `json:"text"`
+}
+
+// InputRichBlockSectionHeading is a section heading block with a level 1-6.
+type InputRichBlockSectionHeading struct {
+	Type string   `json:"type"`
+	Text RichText `json:"text"`
+	Size int      `json:"size"`
+}
+
+// InputRichBlockPreformatted is a preformatted (code) block.
+type InputRichBlockPreformatted struct {
+	Type     string   `json:"type"`
+	Text     RichText `json:"text"`
+	Language string   `json:"language,omitempty"`
+}
+
+// InputRichBlockFooter is a footer block.
+type InputRichBlockFooter struct {
+	Type string   `json:"type"`
+	Text RichText `json:"text"`
+}
+
+// InputRichBlockDivider is a horizontal divider block.
+type InputRichBlockDivider struct {
+	Type string `json:"type"`
+}
+
+// InputRichBlockMathematicalExpression is a LaTeX math block.
+type InputRichBlockMathematicalExpression struct {
+	Type       string `json:"type"`
+	Expression string `json:"expression"`
+}
+
+// InputRichBlockAnchor is a named anchor block for in-page linking.
+type InputRichBlockAnchor struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+// InputRichBlockList is an ordered or unordered list block.
+type InputRichBlockList struct {
+	Type      string                   `json:"type"`
+	Items     []InputRichBlockListItem `json:"items"`
+	IsOrdered bool                     `json:"is_ordered,omitempty"`
+}
+
+// InputRichBlockListItem is a single entry of an InputRichBlockList.
+type InputRichBlockListItem struct {
+	Blocks      []InputRichBlock `json:"blocks"`
+	HasCheckbox bool             `json:"has_checkbox,omitempty"`
+	IsChecked   bool             `json:"is_checked,omitempty"`
+	Value       int              `json:"value,omitempty"`
+	Type        string           `json:"type,omitempty"`
+}
+
+// InputRichBlockBlockQuotation is a block quotation.
+type InputRichBlockBlockQuotation struct {
+	Type string   `json:"type"`
+	Text RichText `json:"text"`
+}
+
+// InputRichBlockPullQuotation is a pull quotation.
+type InputRichBlockPullQuotation struct {
+	Type string   `json:"type"`
+	Text RichText `json:"text"`
+}
+
+// InputRichBlockCollage is a collage of media items.
+type InputRichBlockCollage struct {
+	Type  string       `json:"type"`
+	Media []Inputtable `json:"media"`
+}
+
+// InputRichBlockSlideshow is a slideshow of media items.
+type InputRichBlockSlideshow struct {
+	Type  string       `json:"type"`
+	Media []Inputtable `json:"media"`
+}
+
+// InputRichBlockTable is a table block.
+type InputRichBlockTable struct {
+	Type       string                 `json:"type"`
+	Cells      [][]RichBlockTableCell `json:"cells"`
+	IsBordered bool                   `json:"is_bordered,omitempty"`
+	IsStriped  bool                   `json:"is_striped,omitempty"`
+	IsCompact  bool                   `json:"is_compact,omitempty"`
+	Caption    *RichText              `json:"caption,omitempty"`
+}
+
+// InputRichBlockDetails is a collapsible details block.
+type InputRichBlockDetails struct {
+	Type    string           `json:"type"`
+	Summary RichText        `json:"summary"`
+	Blocks  []InputRichBlock `json:"blocks"`
+	IsOpen  bool             `json:"is_open,omitempty"`
+}
+
+// InputRichBlockMap is a map block showing a geographic location.
+type InputRichBlockMap struct {
+	Type     string    `json:"type"`
+	Location *Location `json:"location"`
+	Zoom     int       `json:"zoom,omitempty"`
+	Width    int       `json:"width"`
+	Height   int       `json:"height"`
+}
+
+// InputRichBlockAnimation is an animation (GIF) block.
+type InputRichBlockAnimation struct {
+	Type      string     `json:"type"`
+	Animation Inputtable `json:"-"`
+}
+
+// InputRichBlockAudio is an audio block.
+type InputRichBlockAudio struct {
+	Type  string     `json:"type"`
+	Audio Inputtable `json:"-"`
+}
+
+// InputRichBlockPhoto is a photo block.
+type InputRichBlockPhoto struct {
+	Type  string     `json:"type"`
+	Photo Inputtable `json:"-"`
+}
+
+// InputRichBlockVideo is a video block.
+type InputRichBlockVideo struct {
+	Type  string     `json:"type"`
+	Video Inputtable `json:"-"`
+}
+
+// InputRichBlockVoiceNote is a voice note block.
+type InputRichBlockVoiceNote struct {
+	Type      string     `json:"type"`
+	VoiceNote Inputtable `json:"-"`
+}
+
+// InputRichBlockThinking is a thinking/reasoning block.
+type InputRichBlockThinking struct {
+	Type string   `json:"type"`
+	Text RichText `json:"text"`
+}
+
+// InputRichBlockExpandableBlockQuotation is an expandable block quotation
+// (Bot API 10.3).
+type InputRichBlockExpandableBlockQuotation struct {
+	Type   string    `json:"type"`
+	Text   RichText  `json:"text"`
+	Credit *RichText `json:"credit,omitempty"`
+}
+
+// InputRichBlockDocument is a document block (Bot API 10.3).
+type InputRichBlockDocument struct {
+	Type     string     `json:"type"`
+	Document Inputtable `json:"-"`
+}
+
+// Interface compliance — every concrete block type implements InputRichBlock.
+func (InputRichBlockParagraph) inputRichBlock()                     {}
+func (InputRichBlockSectionHeading) inputRichBlock()                {}
+func (InputRichBlockPreformatted) inputRichBlock()                  {}
+func (InputRichBlockFooter) inputRichBlock()                        {}
+func (InputRichBlockDivider) inputRichBlock()                       {}
+func (InputRichBlockMathematicalExpression) inputRichBlock()         {}
+func (InputRichBlockAnchor) inputRichBlock()                        {}
+func (InputRichBlockList) inputRichBlock()                          {}
+func (InputRichBlockBlockQuotation) inputRichBlock()                {}
+func (InputRichBlockPullQuotation) inputRichBlock()                 {}
+func (InputRichBlockCollage) inputRichBlock()                       {}
+func (InputRichBlockSlideshow) inputRichBlock()                     {}
+func (InputRichBlockTable) inputRichBlock()                         {}
+func (InputRichBlockDetails) inputRichBlock()                       {}
+func (InputRichBlockMap) inputRichBlock()                           {}
+func (InputRichBlockAnimation) inputRichBlock()                     {}
+func (InputRichBlockAudio) inputRichBlock()                         {}
+func (InputRichBlockPhoto) inputRichBlock()                         {}
+func (InputRichBlockVideo) inputRichBlock()                         {}
+func (InputRichBlockVoiceNote) inputRichBlock()                     {}
+func (InputRichBlockThinking) inputRichBlock()                      {}
+func (InputRichBlockExpandableBlockQuotation) inputRichBlock()      {}
+func (InputRichBlockDocument) inputRichBlock()                      {}

--- a/input_rich_block_test.go
+++ b/input_rich_block_test.go
@@ -1,0 +1,128 @@
+package telebot
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestInputRichBlockParagraphMarshal(t *testing.T) {
+	block := InputRichBlockParagraph{
+		Type: "paragraph",
+		Text: RichText{Kind: RichTextPlain, Plain: "hello"},
+	}
+	b, err := json.Marshal(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	json.Unmarshal(b, &m)
+	if m["type"] != "paragraph" {
+		t.Fatalf("type: %v", m["type"])
+	}
+	if m["text"] != "hello" {
+		t.Fatalf("text: %v", m["text"])
+	}
+}
+
+func TestInputRichBlockDetailsMarshal(t *testing.T) {
+	block := InputRichBlockDetails{
+		Type:    "details",
+		Summary: RichText{Kind: RichTextPlain, Plain: "Thinking"},
+		Blocks: []InputRichBlock{
+			InputRichBlockParagraph{
+				Type: "paragraph",
+				Text: RichText{Kind: RichTextPlain, Plain: "inner content"},
+			},
+		},
+		IsOpen: false,
+	}
+	b, err := json.Marshal(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	json.Unmarshal(b, &m)
+	if m["type"] != "details" {
+		t.Fatalf("type: %v", m["type"])
+	}
+	if m["summary"] != "Thinking" {
+		t.Fatalf("summary: %v", m["summary"])
+	}
+	blocks := m["blocks"].([]interface{})
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	inner := blocks[0].(map[string]interface{})
+	if inner["type"] != "paragraph" {
+		t.Fatalf("inner type: %v", inner["type"])
+	}
+}
+
+func TestInputRichBlockOmitEmptyRichText(t *testing.T) {
+	block := InputRichBlockExpandableBlockQuotation{
+		Type: "expandable_blockquote",
+		Text: RichText{Kind: RichTextPlain, Plain: "quote"},
+	}
+	b, err := json.Marshal(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	json.Unmarshal(b, &m)
+	if _, exists := m["credit"]; exists {
+		t.Fatal("credit should be omitted when nil")
+	}
+}
+
+func TestInputRichBlockTableCaption(t *testing.T) {
+	caption := RichText{Kind: RichTextPlain, Plain: "Table 1"}
+	block := InputRichBlockTable{
+		Type: "table",
+		Cells: [][]RichBlockTableCell{
+			{{Text: &RichText{Kind: RichTextPlain, Plain: "A"}}},
+		},
+		Caption: &caption,
+	}
+	b, err := json.Marshal(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	json.Unmarshal(b, &m)
+	if m["caption"] != "Table 1" {
+		t.Fatalf("caption: %v", m["caption"])
+	}
+}
+
+func TestInputRichMessageBlocksMarshal(t *testing.T) {
+	msg := InputRichMessage{
+		Blocks: []InputRichBlock{
+			InputRichBlockThinking{
+				Type: "thinking",
+				Text: RichText{Kind: RichTextPlain, Plain: "Thinking..."},
+			},
+			InputRichBlockParagraph{
+				Type: "paragraph",
+				Text: RichText{Kind: RichTextPlain, Plain: "The answer"},
+			},
+		},
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	json.Unmarshal(b, &m)
+	blocks := m["blocks"].([]interface{})
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+	first := blocks[0].(map[string]interface{})
+	if first["type"] != "thinking" {
+		t.Fatalf("first block type: %v", first["type"])
+	}
+	second := blocks[1].(map[string]interface{})
+	if second["type"] != "paragraph" {
+		t.Fatalf("second block type: %v", second["type"])
+	}
+}

--- a/media.go
+++ b/media.go
@@ -337,6 +337,14 @@ func (v *Voice) MediaFile() *File {
 	return &v.File
 }
 
+func (v *Voice) InputMedia() InputMedia {
+	return InputMedia{
+		Type:     v.MediaType(),
+		Caption:  v.Caption,
+		Duration: v.Duration,
+	}
+}
+
 // VideoNote represents a video message.
 type VideoNote struct {
 	File

--- a/message.go
+++ b/message.go
@@ -800,3 +800,11 @@ type ReplyParams struct {
 	// (Optional) Position of the quote in the original message in UTF-16 code units.
 	QuotePosition int `json:"quote_position"`
 }
+
+// MessageGenerationStopped is received when a user stops a message
+// generation in a private chat (Bot API 10.3).
+type MessageGenerationStopped struct {
+	Chat            Chat   `json:"chat"`
+	MessageThreadID int    `json:"message_thread_id,omitempty"`
+	DraftID         int64  `json:"draft_id,string"`
+}

--- a/options.go
+++ b/options.go
@@ -103,6 +103,12 @@ type SendOptions struct {
 	// AllowPaidBroadcast allows the message to be sent to users who have not yet
 	// unlocked access to paid channels. Only for messages sent to channels.
 	AllowPaidBroadcast bool
+
+	// CanStop allows the user to stop generation (draft methods only).
+	CanStop bool `json:"-"`
+
+	// KeepOnStop keeps the draft visible after stop (draft methods only).
+	KeepOnStop bool `json:"-"`
 }
 
 func (og *SendOptions) copy() *SendOptions {

--- a/rich.go
+++ b/rich.go
@@ -33,6 +33,19 @@ type InputRichMessage struct {
 	// (Optional) Pass true to skip automatic detection of URLs, email addresses,
 	// mentions, hashtags, cashtags, bot commands and phone numbers in the text.
 	SkipEntityDetection bool `json:"skip_entity_detection,omitempty"`
+
+	// (Optional) Content described using an array of InputRichBlock objects.
+	Blocks []InputRichBlock `json:"blocks,omitempty"`
+
+	// (Optional) Media files referenced by block content.
+	Media []InputRichMessageMedia `json:"media,omitempty"`
+}
+
+// InputRichMessageMedia associates an ID with a media file so that blocks
+// can reference it by ID.
+type InputRichMessageMedia struct {
+	ID    string     `json:"id"`
+	Media Inputtable `json:"-"`
 }
 
 // Send delivers the rich message through bot b to recipient via the
@@ -68,7 +81,7 @@ func (i *InputRichMessage) Send(b *Bot, to Recipient, opt *SendOptions) (*Messag
 // finalized you must Send the complete InputRichMessage to persist it. draftID
 // must be non-zero — updates sharing the same identifier are animated
 // client-side. Of the send options only ThreadID is honored.
-func (b *Bot) SendRichDraft(to Recipient, draftID int, rich *InputRichMessage, opts ...interface{}) error {
+func (b *Bot) SendRichDraft(to Recipient, draftID int64, rich *InputRichMessage, opts ...interface{}) error {
 	if to == nil {
 		return ErrBadRecipient
 	}
@@ -83,12 +96,20 @@ func (b *Bot) SendRichDraft(to Recipient, draftID int, rich *InputRichMessage, o
 
 	params := map[string]string{
 		"chat_id":      to.Recipient(),
-		"draft_id":     strconv.Itoa(draftID),
+		"draft_id":     strconv.FormatInt(draftID, 10),
 		"rich_message": string(data),
 	}
 
-	if sendOpts := b.extractOptions(opts); sendOpts != nil && sendOpts.ThreadID != 0 {
-		params["message_thread_id"] = strconv.Itoa(sendOpts.ThreadID)
+	if sendOpts := b.extractOptions(opts); sendOpts != nil {
+		if sendOpts.ThreadID != 0 {
+			params["message_thread_id"] = strconv.Itoa(sendOpts.ThreadID)
+		}
+		if sendOpts.CanStop {
+			params["can_stop"] = "true"
+		}
+		if sendOpts.KeepOnStop {
+			params["keep_on_stop"] = "true"
+		}
 	}
 
 	_, err = b.Raw("sendRichMessageDraft", params)

--- a/rich_block.go
+++ b/rich_block.go
@@ -24,8 +24,10 @@ const (
 	RichBlockAudioType     = "audio"
 	RichBlockPhotoType     = "photo"
 	RichBlockVideoType     = "video"
-	RichBlockVoiceNote     = "voice_note"
-	RichBlockThinking      = "thinking"
+	RichBlockVoiceNote                = "voice_note"
+	RichBlockThinking                 = "thinking"
+	RichBlockExpandableBlockQuotation = "expandable_blockquote"
+	RichBlockDocument                 = "document"
 )
 
 // RichBlock is a single block of a received RichMessage (Bot API 10.1). It is a
@@ -70,9 +72,10 @@ type RichBlock struct {
 	// Cells are the rows-by-columns of a "table" block.
 	Cells [][]RichBlockTableCell `json:"cells,omitempty"`
 
-	// IsBordered and IsStriped style a "table" block.
+	// IsBordered, IsStriped and IsCompact style a "table" block.
 	IsBordered bool `json:"is_bordered,omitempty"`
 	IsStriped  bool `json:"is_striped,omitempty"`
+	IsCompact  bool `json:"is_compact,omitempty"`
 
 	// Location, Zoom, Width and Height describe a "map" block.
 	Location *Location `json:"location,omitempty"`
@@ -86,6 +89,7 @@ type RichBlock struct {
 	Photo     []Photo    `json:"photo,omitempty"`
 	Video     *Video     `json:"video,omitempty"`
 	VoiceNote *Voice     `json:"voice_note,omitempty"`
+	Document  *Document  `json:"document,omitempty"`
 
 	// HasSpoiler marks an animation, photo or video block as a spoiler.
 	HasSpoiler bool `json:"has_spoiler,omitempty"`

--- a/rich_text.go
+++ b/rich_text.go
@@ -149,6 +149,19 @@ func (r *RichText) UnmarshalJSON(data []byte) error {
 	}
 }
 
+// MarshalJSON encodes a RichText back to the wire form indicated by Kind.
+func (r RichText) MarshalJSON() ([]byte, error) {
+	switch r.Kind {
+	case RichTextPlain:
+		return json.Marshal(r.Plain)
+	case RichTextArray:
+		return json.Marshal(r.Parts)
+	default: // RichTextEntity
+		type alias RichText
+		return json.Marshal(alias(r))
+	}
+}
+
 // String renders the RichText as plain text, recursively flattening arrays and
 // entities. Entities without textual content (anchors, dividers) contribute
 // nothing; custom emoji contribute their alternative text.

--- a/rich_text_test.go
+++ b/rich_text_test.go
@@ -1,0 +1,103 @@
+package telebot
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRichTextMarshalPlain(t *testing.T) {
+	rt := RichText{Kind: RichTextPlain, Plain: "hello world"}
+	b, err := json.Marshal(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != `"hello world"` {
+		t.Fatalf("expected %q, got %s", "hello world", b)
+	}
+}
+
+func TestRichTextMarshalPlainEmpty(t *testing.T) {
+	rt := RichText{Kind: RichTextPlain, Plain: ""}
+	b, err := json.Marshal(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != `""` {
+		t.Fatalf("expected empty string, got %s", b)
+	}
+}
+
+func TestRichTextMarshalArray(t *testing.T) {
+	rt := RichText{
+		Kind: RichTextArray,
+		Parts: []RichText{
+			{Kind: RichTextPlain, Plain: "hello "},
+			{Kind: RichTextPlain, Plain: "world"},
+		},
+	}
+	b, err := json.Marshal(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != `["hello ","world"]` {
+		t.Fatalf("unexpected: %s", b)
+	}
+}
+
+func TestRichTextMarshalEntity(t *testing.T) {
+	inner := RichText{Kind: RichTextPlain, Plain: "bold text"}
+	rt := RichText{
+		Kind: RichTextEntity,
+		Type: RichBold,
+		Text: &inner,
+	}
+	b, err := json.Marshal(rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["type"] != "bold" {
+		t.Fatalf("expected type=bold, got %v", m["type"])
+	}
+	if m["text"] != "bold text" {
+		t.Fatalf("expected text=bold text, got %v", m["text"])
+	}
+}
+
+func TestRichTextRoundTrip(t *testing.T) {
+	original := RichText{
+		Kind: RichTextArray,
+		Parts: []RichText{
+			{Kind: RichTextPlain, Plain: "hello "},
+			{
+				Kind: RichTextEntity,
+				Type: RichBold,
+				Text: &RichText{Kind: RichTextPlain, Plain: "world"},
+			},
+		},
+	}
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded RichText
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Kind != RichTextArray {
+		t.Fatalf("expected array, got %d", decoded.Kind)
+	}
+	if len(decoded.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(decoded.Parts))
+	}
+	if decoded.Parts[0].Plain != "hello " {
+		t.Fatalf("part 0: %q", decoded.Parts[0].Plain)
+	}
+	if decoded.Parts[1].Type != RichBold {
+		t.Fatalf("part 1 type: %q", decoded.Parts[1].Type)
+	}
+}

--- a/telebot.go
+++ b/telebot.go
@@ -124,6 +124,7 @@ const (
 	OnDeletedBusinessMessages = "\adeleted_business_messages"
 	OnGuestMessage            = "\aguest_message"
 	OnPurchasedPaidMedia      = "\apurchased_paid_media"
+	OnGenerationStopped       = "\astopped_message_generation"
 )
 
 // ChatAction is a client-side status indicating bot activity.

--- a/update.go
+++ b/update.go
@@ -30,6 +30,7 @@ type Update struct {
 	DeletedBusinessMessages *BusinessMessagesDeleted `json:"deleted_business_messages"`
 	GuestMessage            *Message                 `json:"guest_message"`
 	PurchasedPaidMedia      *PaidMediaPurchased      `json:"purchased_paid_media"`
+	StoppedMessageGeneration *MessageGenerationStopped `json:"stopped_message_generation,omitempty"`
 }
 
 // ProcessUpdate processes a single incoming update.
@@ -372,6 +373,10 @@ func (b *Bot) ProcessContext(c Context) {
 	}
 	if u.PurchasedPaidMedia != nil {
 		b.handle(OnPurchasedPaidMedia, c)
+		return
+	}
+	if u.StoppedMessageGeneration != nil {
+		b.handle(OnGenerationStopped, c)
 		return
 	}
 }


### PR DESCRIPTION
- RichText.MarshalJSON for send-side block serialization
- InputRichBlock interface + 23 concrete block types
- InputRichMessage.Blocks/Media fields, InputRichMessageMedia
- Receive-side: IsCompact, Document, expandable blockquote
- SendOptions.CanStop/KeepOnStop for draft stop-generation
- MessageGenerationStopped type + Update routing + Context accessor
- Voice implements Inputtable

made with Opus 4.6, using it in my bot. So far so good. 
Thinking indication, expandable thinking blocks, ability to stop generation. MacOS telegram doesn't have stop button yet but works fine on iPhone.